### PR TITLE
Add support for CF Volume Services

### DIFF
--- a/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfService.java
+++ b/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfService.java
@@ -31,14 +31,18 @@ public class CfService {
 	private static final String TAGS = "tags";
 
 	private static final String CREDENTIALS = "credentials";
+	private static final String VOLUMES = "volume_mounts";
 
 	private final Map<String, Object> serviceData;
 
 	private final CfCredentials cfCredentials;
 
+	private final List<CfVolume> cfVolumes;
+
 	public CfService(Map<String, Object> serviceData) {
 		this.serviceData = serviceData;
 		this.cfCredentials = createCredentials();
+		this.cfVolumes = createVolumes();
 	}
 
 	public CfCredentials createCredentials() {
@@ -52,12 +56,27 @@ public class CfService {
 		return new CfCredentials(credentials);
 	}
 
+	public List<CfVolume> createVolumes() {
+		List<CfVolume> volumes = new ArrayList<>();
+		if (this.serviceData.containsKey(VOLUMES)) {
+			List<Map<String,String>> volumeDatas = (List<Map<String,String>>) this.serviceData.get(VOLUMES);
+			for (Map<String,String> volumeData : volumeDatas) {
+				volumes.add(new CfVolume(volumeData));
+			}
+		}
+		return volumes;
+	}
+
 	public Map<String, Object> getMap() {
 		return this.serviceData;
 	}
 
 	public CfCredentials getCredentials() {
 		return this.cfCredentials;
+	}
+
+	List<CfVolume> getVolumes() {
+		return cfVolumes;
 	}
 
 	public List<String> getTags() {

--- a/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfVolume.java
+++ b/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfVolume.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.core;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Access individual volume.
+ *
+ * @author Paul Warren
+ */
+public class CfVolume {
+
+	private static final String MODE_READONLY = "r";
+
+	private final Map<String, String> volumeData;
+
+	public CfVolume(Map<String, String> volumeData) {
+		Objects.requireNonNull(volumeData);
+		this.volumeData = volumeData;
+	}
+
+	public Map<String, String> getMap() {
+		return volumeData;
+	}
+
+	public Path getPath() {
+		return Paths.get(volumeData.get("container_dir"));
+	}
+
+	public Mode getMode() {
+		if (MODE_READONLY.equals(volumeData.get("mode"))) {
+			return Mode.READ_ONLY;
+		}
+		return Mode.READ_WRITE;
+	}
+
+	public enum Mode {
+		READ_ONLY,
+		READ_WRITE,
+	}
+}

--- a/java-cfenv/src/test/java/io/pivotal/cfenv/core/CfEnvTests.java
+++ b/java-cfenv/src/test/java/io/pivotal/cfenv/core/CfEnvTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Mark Pollack
+ * @author Paul Warren
  */
 public class CfEnvTests {
 
@@ -67,7 +68,7 @@ public class CfEnvTests {
 		CfEnv cfEnv = new CfEnv();
 
 		List<CfService> cfServices = cfEnv.findAllServices();
-		assertThat(cfServices.size()).isEqualTo(2);
+		assertThat(cfServices.size()).isEqualTo(3);
 
 		CfService cfService = cfEnv.findServiceByTag("mysql");
 		assertThat(cfService.getString("blah")).isNull();
@@ -115,6 +116,12 @@ public class CfEnvTests {
 		assertThat(cfCredentials.getHost()).isEqualTo("10.0.4.30");
 		assertThat(cfService.getName()).isEqualTo("redis-binding");
 
+		// Test Volume Services
+
+		cfService = cfEnv.findServiceByName("nfs1");
+		assertThat(cfService.getTags()).containsExactly("nfs");
+		List<CfVolume> cfVolumes = cfService.getVolumes();
+		assertNfsVolumes(cfVolumes);
 	}
 
 	private void assertMySqlCredentials(CfCredentials cfCredentials) {
@@ -350,6 +357,21 @@ public class CfEnvTests {
 		CfService cfService = cfEnv.findServiceByTag("efs");
 		// should not throw exception
 		cfService.existsByCredentialsContainsUriField("foo");
+	}
+
+	private void assertNfsVolumes(List<CfVolume> cfVolumes) {
+		assertThat(cfVolumes.size()).isEqualTo(1);
+
+		Map<String, String> cfVolumeMap = cfVolumes.get(0).getMap();
+		assertThat(cfVolumeMap)
+				.containsEntry("container_dir", "/var/vcap/data/78525ee7-196c-4ed4-8ac6-857d15334631")
+				.containsEntry("device_type", "shared")
+				.containsEntry("mode", "rw");
+
+		CfVolume cfVolume = cfVolumes.get(0);
+
+		assertThat(cfVolume.getPath().toString()).isEqualTo("/var/vcap/data/78525ee7-196c-4ed4-8ac6-857d15334631");
+		assertThat(cfVolume.getMode()).isEqualTo(CfVolume.Mode.READ_WRITE);
 	}
 
 	@Test

--- a/java-cfenv/src/test/resources/vcap-services.json
+++ b/java-cfenv/src/test/resources/vcap-services.json
@@ -40,5 +40,27 @@
         "redis"
       ]
     }
+  ],
+  "nfs": [
+    {
+      "binding_name": null,
+      "credentials": {},
+      "instance_name": "nfs1",
+      "label": "nfs",
+      "name": "nfs1",
+      "plan": "Existing",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "nfs"
+      ],
+      "volume_mounts": [
+        {
+          "container_dir": "/var/vcap/data/78525ee7-196c-4ed4-8ac6-857d15334631",
+          "device_type": "shared",
+          "mode": "rw"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Hi Scott,

Apologies for the time it took but here is a PR adding support for CF Volume Services.

In case it is useful the Open Service Broker API specification for volume services are [here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#volume-services) and [here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#volume-mount-object).

In a nutshell, an app can be bound to multiple volume services and each service can have multiple mounts (although in practice *our* brokers only ever issue one mount per service).  

I prefer strongly typed things and, as the project java settings are set to 8, I considered exposing the `container_dir` as both `java.nio.Path` and `java.io.File`, concluding that `java.nio.Path` was a slightly better fit.  I guess it could also be a String but I like that option less personally.   Please let me know if you have any string feelings on this, one way or the other.

Hopefully, I kept reasonably well to the native code style.

I pushed a sample project showing this in use [here](https://github.com/paulcwarren/java-cfenv-volumes).

The Diego Persistence story for this work is: [#164283399](https://www.pivotaltracker.com/story/show/164283399)

Many thanks
_Paul
@dennisdenuto, @julian-hj