### PR TITLE
Enable Redis SSL when Cloud Foundry credentials include tls_port.

### DIFF
--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessor.java
@@ -16,6 +16,7 @@
 package io.pivotal.cfenv.spring.boot;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.pivotal.cfenv.core.CfCredentials;
 import io.pivotal.cfenv.core.CfService;
@@ -46,8 +47,15 @@ public class RedisCfEnvProcessor implements CfEnvProcessor {
 
 		if (uri == null) {
 			properties.put("spring.redis.host", cfCredentials.getHost());
-			properties.put("spring.redis.port", cfCredentials.getPort());
 			properties.put("spring.redis.password", cfCredentials.getPassword());
+
+			Optional<String> tlsPort = Optional.ofNullable(cfCredentials.getString("tls_port"));
+			if (tlsPort.isPresent()) {
+				properties.put("spring.redis.port", tlsPort.get());
+				properties.put("spring.redis.ssl", "true");
+			} else {
+				properties.put("spring.redis.port", cfCredentials.getPort());
+			}
 		} else {
 			UriInfo uriInfo = new UriInfo(uri);
 			properties.put("spring.redis.host", uriInfo.getHost());

--- a/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-redis-info-with-tls-port.json
+++ b/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-redis-info-with-tls-port.json
@@ -1,0 +1,12 @@
+{
+  "name": "$serviceName",
+  "label": "rediscloud",
+  "plan": "free",
+  "tags": [ "redis", "key-value" ],
+  "credentials": {
+    "hostname": "$hostname",
+    "port": "$port",
+    "password": "$password",
+    "tls_port": "$tls_port"
+  }
+}


### PR DESCRIPTION
Hi, 

We (the PCF Redis team) have exposed a tls_port in our CloudFoundry VCAP_SERVICES credentials. This PR allows Spring to automatically consume this tls_port and connect to Redis over SSL when possible. 

Best!
Mirah & @gregttn 