### PR TITLE
don't set driver-class-name except for mariadb driver

### DIFF
--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
@@ -37,6 +37,7 @@ import org.springframework.core.env.MutablePropertySources;
 
 /**
  * @author Mark Pollack
+ * @author Thomas Risberg
  */
 public class CfDataSourceEnvironmentPostProcessor implements EnvironmentPostProcessor,
 		Ordered, ApplicationListener<ApplicationEvent> {
@@ -80,7 +81,7 @@ public class CfDataSourceEnvironmentPostProcessor implements EnvironmentPostProc
 				properties.put("spring.datasource.username", cfJdbcService.getUsername());
 				properties.put("spring.datasource.password", cfJdbcService.getPassword());
 				Object driverClassName = cfJdbcService.getDriverClassName();
-				if (driverClassName != null) {
+				if (driverClassName != null && ((String)driverClassName).startsWith("org.mariadb.jdbc")) {
 					properties.put("spring.datasource.driver-class-name", driverClassName);
 				}
 

--- a/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/MySqlJdbcUrlCreator.java
+++ b/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/MySqlJdbcUrlCreator.java
@@ -21,6 +21,7 @@ import io.pivotal.cfenv.core.UriInfo;
 
 /**
  * @author Mark Pollack
+ * @author Thomas Risberg
  */
 public class MySqlJdbcUrlCreator extends AbstractJdbcUrlCreator {
 
@@ -46,11 +47,11 @@ public class MySqlJdbcUrlCreator extends AbstractJdbcUrlCreator {
 	public String getDriverClassName() {
 		String driverClassNameToUse = null;
 		try {
-			driverClassNameToUse = "org.mariadb.jdbc.Driver";
+			driverClassNameToUse = "com.mysql.cj.jdbc.Driver";
 			Class.forName(driverClassNameToUse, false, getClass().getClassLoader());
 		} catch (ClassNotFoundException e) {
 			try {
-				driverClassNameToUse = "com.mysql.cj.jdbc.Driver";
+				driverClassNameToUse = "org.mariadb.jdbc.Driver";
 				Class.forName(driverClassNameToUse, false, getClass().getClassLoader());
 			} catch (ClassNotFoundException e2) {
 				return null;


### PR DESCRIPTION
- for boot we shouldn't have to set the driver class name, it should be automatically loaded/detected

- only exception is for mysql with maridb driver since boot seems to force mysql driver