### PR TITLE
Add support to pass credential defined in credhub to a bound application

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -230,6 +230,7 @@ The list of supported services are:
 * Cassandara
 * MongoDB
 * Redis
+* CredHub
 
 If, for any reason, you need to disable processing of a specific service instance, you can do so by setting the following flag in your application properties:
 [source]

--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CredHubCfEnvProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CredHubCfEnvProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pivotal.cfenv.spring.boot;
+
+import java.util.Map;
+
+import io.pivotal.cfenv.core.CfCredentials;
+import io.pivotal.cfenv.core.CfService;
+
+
+/**
+ * Retrieve CredHub secrets from {@link CfCredentials} and set Boot properties.
+ *
+ * @author Jakob Fels
+ **/
+public class CredHubCfEnvProcessor implements CfEnvProcessor {
+
+	@Override
+	public boolean accept(CfService service) {
+		return service.existsByTagIgnoreCase("credhub") ||
+				service.existsByLabelStartsWith("credhub");
+	}
+
+	@Override
+	public void process(CfCredentials cfCredentials, Map<String, Object> properties) {
+		Map<String, Object> allCredentials = cfCredentials.getMap();
+		for (Map.Entry<String, Object> entry : allCredentials.entrySet()) {
+			properties.put(entry.getKey(), entry.getValue());
+		}
+	}
+
+	@Override
+	public CfEnvProcessorProperties getProperties() {
+		return CfEnvProcessorProperties.builder()
+				.serviceName("CredHub")
+				.build();
+	}
+}

--- a/java-cfenv-boot/src/main/resources/META-INF/spring.factories
+++ b/java-cfenv-boot/src/main/resources/META-INF/spring.factories
@@ -11,6 +11,7 @@ io.pivotal.cfenv.spring.boot.CfEnvProcessor=\
   io.pivotal.cfenv.spring.boot.RedisCfEnvProcessor,\
   io.pivotal.cfenv.spring.boot.MongoCfEnvProcessor,\
   io.pivotal.cfenv.spring.boot.AmqpCfEnvProcessor,\
+  io.pivotal.cfenv.spring.boot.CredHubCfEnvProcessor,\
   io.pivotal.cfenv.spring.boot.CassandraCfEnvProcessor
 
 

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/CredHubCfEnvProcessorTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/CredHubCfEnvProcessorTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+
+import io.pivotal.cfenv.test.AbstractCfEnvTests;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jakob Fels
+ */
+public class CredHubCfEnvProcessorTests extends AbstractCfEnvTests {
+
+	@Test
+	public void simpleService() {
+		mockVcapServices(readTestDataFile("test-credhub-service.json"));
+
+		Environment environment = getEnvironment();
+
+		assertThat(environment.getProperty("some.external.service.password")).isEqualTo("p4ssw0rd");
+	}
+
+}

--- a/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-credhub-service.json
+++ b/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-credhub-service.json
@@ -1,0 +1,20 @@
+{
+  "credhub": [
+	{
+	  "binding_name": null,
+	  "credentials": {
+		"some.external.service.password": "p4ssw0rd"
+	  },
+	  "instance_name": "credhub",
+	  "label": "credhub",
+	  "name": "credhub",
+	  "plan": "default",
+	  "provider": null,
+	  "syslog_drain_url": null,
+	  "tags": [
+		"credhub"
+	  ],
+	  "volume_mounts": []
+	}
+  ]
+}


### PR DESCRIPTION
This adds support for binding credentials defined via the CredHub service broker.