### PR TITLE
Add automatic module names for better consumption in Java 9 projects

### DIFF
--- a/java-cfenv-boot-pivotal-scs/pom.xml
+++ b/java-cfenv-boot-pivotal-scs/pom.xml
@@ -22,4 +22,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.pivotal.cfenv.boot.scs</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java-cfenv-boot-pivotal-sso/pom.xml
+++ b/java-cfenv-boot-pivotal-sso/pom.xml
@@ -37,4 +37,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.pivotal.cfenv.boot.sso</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java-cfenv-boot/pom.xml
+++ b/java-cfenv-boot/pom.xml
@@ -27,4 +27,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.pivotal.cfenv.spring.boot</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java-cfenv-jdbc/pom.xml
+++ b/java-cfenv-jdbc/pom.xml
@@ -30,4 +30,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.pivotal.cfenv.jdbc</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java-cfenv-test-support/pom.xml
+++ b/java-cfenv-test-support/pom.xml
@@ -14,37 +14,53 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>java-cfenv-parent</artifactId>
-		<groupId>io.pivotal.cfenv</groupId>
-		<version>2.2.3.BUILD-SNAPSHOT</version>
-	</parent>
-	<modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>java-cfenv-parent</artifactId>
+        <groupId>io.pivotal.cfenv</groupId>
+        <version>2.2.3.BUILD-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-	<artifactId>java-cfenv-test-support</artifactId>
-	<packaging>jar</packaging>
-	<name>Java CF Env Test Support</name>
-	<description>Java CF Env Test Support Library</description>
+    <artifactId>java-cfenv-test-support</artifactId>
+    <packaging>jar</packaging>
+    <name>Java CF Env Test Support</name>
+    <description>Java CF Env Test Support Library</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>io.pivotal.cfenv</groupId>
-			<artifactId>java-cfenv</artifactId>
-			<version>2.2.3.BUILD-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>io.pivotal.cfenv</groupId>
-			<artifactId>java-cfenv</artifactId>
-			<type>test-jar</type>
-			<version>2.2.3.BUILD-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jmockit</groupId>
-			<artifactId>jmockit</artifactId>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>io.pivotal.cfenv</groupId>
+            <artifactId>java-cfenv</artifactId>
+            <version>2.2.3.BUILD-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.pivotal.cfenv</groupId>
+            <artifactId>java-cfenv</artifactId>
+            <type>test-jar</type>
+            <version>2.2.3.BUILD-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.pivotal.cfenv.test</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java-cfenv/pom.xml
+++ b/java-cfenv/pom.xml
@@ -37,7 +37,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/java-cfenv/pom.xml
+++ b/java-cfenv/pom.xml
@@ -44,6 +44,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.pivotal.cfenv.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,9 @@
         <module>java-cfenv-test-support</module>
         <module>java-cfenv-jdbc</module>
         <module>java-cfenv-boot</module>
-	    <module>java-cfenv-boot-pivotal-scs</module>
+        <module>java-cfenv-boot-pivotal-scs</module>
         <module>java-cfenv-boot-pivotal-sso</module>
-        <!--
-      <module>java-cfenv-docs</module>  -->
+        <!-- <module>java-cfenv-docs</module> -->
     </modules>
 
     <developers>
@@ -133,8 +132,8 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>javadoc</id>
@@ -153,7 +152,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-maven-plugin.version}</version>
                 <configuration>
-                    <!-- Most of the tests are not thread-safe due to static mocking in CfEnvMock  -->
+                    <!-- Most of the tests are not thread-safe due to static mocking in CfEnvMock -->
                     <runOrder>alphabetical</runOrder>
                     <includes>
                         <include>**/*Tests.java</include>
@@ -188,7 +187,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
@@ -226,7 +224,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -236,7 +234,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
This is how this library is consumed in a Java 11 project:
```
module foo {
    requires java.cfenv;
    requires java.cfenv.jdbc;
    // And the rest of the modules...
}
```
Unfortunately, this produces the following warning:
>Name of automatic module 'java.cfenv' is unstable, it is derived from the module's file name.

That's because when a JAR does not contain a `module-info.class` Java assigns an automatic module name based on the JAR's name (`java-cfenv-2.2.2.RELEASE.jar` -> `java.cfenv`). The cheapest way to remove this warning is to define a custom automatic module name with the help of the `maven-jar-plugin`. That way, Java wouldn't have to infer the module's name from the name of the JAR.

See http://branchandbound.net/blog/java/2017/12/automatic-module-name/ for more info.

I've used the package names as module names, since that's what's recommended by Mark Reinhold (see [Proposal: #AutomaticModuleNames (revised)](http://mail.openjdk.java.net/pipermail/jpms-spec-experts/2017-May/000687.html)):
>Strongly recommend that all modules be named according to the reverse Internet domain-name convention.  A module's name should correspond to the name of its principal exported API package, which should also follow that convention.  If a module does not have such a package, or if for legacy reasons it must have a name that does not correspond to one of its exported packages, then its name should at least start with the reversed form of an Internet domain with which the author is associated.

With this PR, the library would be consumable in the following way:
```
module foo {
    requires io.pivotal.cfenv.core;
    requires io.pivotal.cfenv.jdbc;
    requires io.pivotal.cfenv.spring.boot;
    requires io.pivotal.cfenv.boot.sso;
    requires io.pivotal.cfenv.boot.scs;
}
```
