### PR TITLE
Add support for bootstrapping oauth2 resource servers from SSO binding

### DIFF
--- a/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/CfSingleSignOnProcessor.java
+++ b/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/CfSingleSignOnProcessor.java
@@ -27,7 +27,6 @@ import io.pivotal.cfenv.core.CfCredentials;
 import io.pivotal.cfenv.core.CfService;
 import io.pivotal.cfenv.spring.boot.CfEnvProcessor;
 import io.pivotal.cfenv.spring.boot.CfEnvProcessorProperties;
-import org.springframework.util.ClassUtils;
 
 /**
  * @author Pivotal Application Single Sign-On

--- a/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/CfSingleSignOnProcessor.java
+++ b/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/CfSingleSignOnProcessor.java
@@ -59,6 +59,8 @@ public class CfSingleSignOnProcessor implements CfEnvProcessor {
         properties.put(SSO_SERVICE, authDomain);
         properties.put(SPRING_SECURITY_CLIENT + ".provider." + PROVIDER_ID + ".issuer-uri", issuer + "/oauth/token");
         properties.put(SPRING_SECURITY_CLIENT + ".provider." + PROVIDER_ID + ".authorization-uri", authDomain + "/oauth/authorize");
+        properties.put("spring.security.oauth2.resourceserver.jwt.issuer-uri", issuer + "/oauth/token");
+
 
         ArrayList<String> grantTypes = (ArrayList<String>) cfCredentials.getMap().get("grant_types");
         if (grantTypes != null && isAuthCodeAndClientCreds(grantTypes)) {

--- a/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/CfSingleSignOnProcessor.java
+++ b/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/CfSingleSignOnProcessor.java
@@ -27,6 +27,7 @@ import io.pivotal.cfenv.core.CfCredentials;
 import io.pivotal.cfenv.core.CfService;
 import io.pivotal.cfenv.spring.boot.CfEnvProcessor;
 import io.pivotal.cfenv.spring.boot.CfEnvProcessorProperties;
+import org.springframework.util.ClassUtils;
 
 /**
  * @author Pivotal Application Single Sign-On
@@ -49,6 +50,7 @@ public class CfSingleSignOnProcessor implements CfEnvProcessor {
         return SpringSecurityDetector.isSpringSecurityPresent() && service.existsByLabelStartsWith(PIVOTAL_SSO_LABEL);
     }
 
+
     @Override
     public void process(CfCredentials cfCredentials, Map<String, Object> properties) {
         String clientId = cfCredentials.getString("client_id");
@@ -59,8 +61,9 @@ public class CfSingleSignOnProcessor implements CfEnvProcessor {
         properties.put(SSO_SERVICE, authDomain);
         properties.put(SPRING_SECURITY_CLIENT + ".provider." + PROVIDER_ID + ".issuer-uri", issuer + "/oauth/token");
         properties.put(SPRING_SECURITY_CLIENT + ".provider." + PROVIDER_ID + ".authorization-uri", authDomain + "/oauth/authorize");
-        properties.put("spring.security.oauth2.resourceserver.jwt.issuer-uri", issuer + "/oauth/token");
-
+        if(SpringSecurityDetector.isSpringResourceServerPresent()) {
+            properties.put("spring.security.oauth2.resourceserver.jwt.issuer-uri", issuer + "/oauth/token");
+        }
 
         ArrayList<String> grantTypes = (ArrayList<String>) cfCredentials.getMap().get("grant_types");
         if (grantTypes != null && isAuthCodeAndClientCreds(grantTypes)) {

--- a/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/SpringSecurityDetector.java
+++ b/java-cfenv-boot-pivotal-sso/src/main/java/io/pivotal/cfenv/boot/sso/SpringSecurityDetector.java
@@ -23,11 +23,13 @@ import org.springframework.util.ClassUtils;
 public abstract class SpringSecurityDetector {
     private static boolean usingSpringSecurity;
     private static boolean usingLegacy;
+    private static boolean usingSpringResourceServer;
 
     static {
         ClassLoader classLoader = SpringSecurityDetector.class.getClassLoader();
         usingSpringSecurity = ClassUtils.isPresent("org.springframework.security.core.Authentication", classLoader);
         usingLegacy = ClassUtils.isPresent("org.springframework.security.oauth2.common.DefaultOAuth2AccessToken", classLoader);
+        usingSpringResourceServer = ClassUtils.isPresent("org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider", classLoader);
     }
 
     static boolean isSpringSecurityPresent() {
@@ -37,4 +39,7 @@ public abstract class SpringSecurityDetector {
     static boolean isLegacySpringSecurityPresent() {
         return usingLegacy;
     }
+    static boolean isSpringResourceServerPresent() { return usingSpringResourceServer; }
+
+
 }


### PR DESCRIPTION
This allows oauth2 resource servers to be configured from SSO binding. Currently, it requires managing configuration manually.