### PR TITLE
Fix argument format in sync-to-maven-central.sh

### DIFF
--- a/ci/scripts/sync-to-maven-central.sh
+++ b/ci/scripts/sync-to-maven-central.sh
@@ -6,6 +6,6 @@ readonly CONFIG_DIR="$(pwd)/git-repo/ci/config"
 
 java -jar /opt/concourse-release-scripts*.jar \
   --spring.config.location="${CONFIG_DIR}/release-scripts.yml" \
-  publishToCentral 'RELEASE' "$BUILD_INFO_LOCATION artifactory-repo"
+  publishToCentral 'RELEASE' "$BUILD_INFO_LOCATION" "artifactory-repo"
 
 echo "Sync complete"


### PR DESCRIPTION
Current quoting causes that '$BUILD_INFO artifactory-repo' is passed as 1 argument and so count validation in concourse-release-scripts fails.