### PR TITLE
Get string null check

### DIFF
--- a/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfCredentials.java
+++ b/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfCredentials.java
@@ -15,11 +15,7 @@
  */
 package io.pivotal.cfenv.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Access service credentials.
@@ -173,7 +169,8 @@ public class CfCredentials {
 	public String getString(String... keys) {
 		if (this.credentialsData != null) {
 			for (String key : keys) {
-				if (this.credentialsData.containsKey(key)) {
+				if (this.credentialsData.containsKey(key)
+						&& Objects.nonNull(this.credentialsData.get(key))) {
 					return this.credentialsData.get(key).toString();
 				}
 			}


### PR DESCRIPTION
We were unit testing a piece of code where the getUsername() in CfCredentials.class is getting called. In case of null in username/password we put a custom Exception to be thrown, later in code depending upon the return value of getUsername() or getPassword(). However, assertion failed as it was a NPE instead! A null-check before accessing toString() on the map data helps.