### PR TITLE
CfEnv: allow passing in values of VCAP_SERVICES & VCAP_APPLICATION

### DIFF
--- a/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfEnv.java
+++ b/java-cfenv/src/main/java/io/pivotal/cfenv/core/CfEnv.java
@@ -39,27 +39,29 @@ public class CfEnv {
 	private CfApplication cfApplication;
 
 	public CfEnv() {
-		/* TODO pick small json parser and package as a shadowed jar */
-		ObjectMapper objectMapper = new ObjectMapper();
-		parseVcapServices(objectMapper);
-		parseVcapApplication(objectMapper);
+		this(System.getenv(VCAP_APPLICATION), System.getenv(VCAP_SERVICES));
 	}
 
-	private void parseVcapApplication(ObjectMapper objectMapper) {
+	public CfEnv(String vcapApplicationJson, String vcapServicesJson) {
+		/* TODO pick small json parser and package as a shadowed jar */
+		ObjectMapper objectMapper = new ObjectMapper();
+		parseVcapServices(objectMapper, vcapServicesJson);
+		parseVcapApplication(objectMapper, vcapApplicationJson);
+	}
+
+	private void parseVcapApplication(ObjectMapper objectMapper, String vcapApplicationJson) {
 		try {
-			String vcapApplicationJson = System.getenv(VCAP_APPLICATION);
 			if (vcapApplicationJson != null && vcapApplicationJson.length() > 0) {
 				Map<String, Object> applicationData = objectMapper.readValue(vcapApplicationJson, Map.class);
 				this.cfApplication = new CfApplication(applicationData);
 			}
 		} catch (Exception e) {
-			 throw new IllegalStateException("Could not access/parse " + VCAP_APPLICATION + "environment variable.", e);
+			 throw new IllegalStateException("Could not parse " + VCAP_APPLICATION + "environment variable.", e);
 		}
 	}
 
-	private void parseVcapServices(ObjectMapper objectMapper) {
+	private void parseVcapServices(ObjectMapper objectMapper, String vcapServicesJson) {
 		try {
-			String vcapServicesJson = System.getenv(VCAP_SERVICES);
 			if (vcapServicesJson != null && vcapServicesJson.length() > 0) {
 				Map<String, List<Map<String, Object>>> rawServicesMap = objectMapper.readValue(vcapServicesJson, Map.class);
 				rawServicesMap.values().stream()
@@ -67,7 +69,7 @@ public class CfEnv {
 						.forEach(serviceData -> cfServices.add(new CfService(serviceData)));
 			}
 		} catch (Exception e) {
-			throw new IllegalStateException("Could not access/parse " + VCAP_SERVICES + " environment variable.", e);
+			throw new IllegalStateException("Could not parse " + VCAP_SERVICES + " environment variable.", e);
 		}
 	}
 


### PR DESCRIPTION
This change makes it easier to test components using CfEnv to parse a given VCAP_SERVICES string.

As can be seen in CfEnv's tests, it is possible to mock `System.getenv` with JMockit, but patching globally scoped objects is quite invasive and also requires configuring a Java agent.

This change adds a second constructor to CfEnv, so that the VCAP_SERVICES value can simply be passed in.

A Spring Configuration class like the following...

```java
@Configuration
class FooConfiguration {
    public FooConfiguration(Environment environment) {
        this.environment = environment;
    }

    @Bean
    public Foo foo() {
        CfEnv cfEnv = new CfEnv(environment.get("VCAP_APPLICATION"), environment.get("VCAP_SERVICES"));
        ...
    }
}
```

...can then be easily tested using `MockEnvironment`.