### PR TITLE
Restores support for user:pass@host/db style SQLServer URI

### DIFF
--- a/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/SqlServerJdbcTests.java
+++ b/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/SqlServerJdbcTests.java
@@ -34,6 +34,21 @@ public class SqlServerJdbcTests extends AbstractJdbcTests {
 	@Test
 	public void sqlServerServiceCreation() {
 		mockVcapServices(getServicesPayload(
+				getSqlserverServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)
+		));
+
+		CfJdbcEnv cfJdbcEnv = new CfJdbcEnv();
+		CfJdbcService cfJdbcService = cfJdbcEnv.findJdbcServiceByName(SERVICE_NAME);
+		assertThat(cfJdbcService.getDriverClassName()).isEqualTo("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+
+		String jdbcUrl = cfJdbcEnv.findJdbcServiceByName(SERVICE_NAME).getJdbcUrl();
+		String expectedJdbcUrl = getExpectedJdbcUrl(SqlServerJdbcUrlCreator.SQLSERVER_SCHEME, INSTANCE_NAME);
+		assertThat(jdbcUrl).isEqualTo(expectedJdbcUrl);
+	}
+
+	@Test
+	public void sqlServerServiceCreationUserProvided() {
+		mockVcapServices(getServicesPayload(
 				getSqlserverUserProvidedServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)
 		));
 
@@ -47,12 +62,27 @@ public class SqlServerJdbcTests extends AbstractJdbcTests {
 	}
 
 	@Test
+	public void sqlServerServiceCreationUserProvidedWithProps() {
+		mockVcapServices(getServicesPayload(
+				getSqlserverUserProvidedWithPropsServicePayload(SERVICE_NAME, hostname, port, username, password, INSTANCE_NAME)
+		));
+
+		CfJdbcEnv cfJdbcEnv = new CfJdbcEnv();
+		CfJdbcService cfJdbcService = cfJdbcEnv.findJdbcServiceByName(SERVICE_NAME);
+		assertThat(cfJdbcService.getDriverClassName()).isEqualTo("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+
+		String jdbcUrl = cfJdbcEnv.findJdbcServiceByName(SERVICE_NAME).getJdbcUrl();
+		String expectedJdbcUrl = getExpectedJdbcUrlWithProps(SqlServerJdbcUrlCreator.SQLSERVER_SCHEME, INSTANCE_NAME);
+		assertThat(jdbcUrl).isEqualTo(expectedJdbcUrl);
+	}
+
+	@Test
 	public void sqlServerServiceCreationWithSpecialChars() {
 		String userWithSpecialChars = "u%u:u+";
 		String passwordWithSpecialChars = "p%p:p+";
 
 		mockVcapServices(getServicesPayload(
-				getSqlserverUserProvidedServicePayload(SERVICE_NAME, hostname, port, userWithSpecialChars,
+				getSqlserverServicePayload(SERVICE_NAME, hostname, port, userWithSpecialChars,
 						passwordWithSpecialChars, INSTANCE_NAME)
 		));
 
@@ -71,6 +101,11 @@ public class SqlServerJdbcTests extends AbstractJdbcTests {
 				scheme, hostname, port, name, UriInfo.urlEncode(username), UriInfo.urlEncode(password));
 	}
 
+	protected String getExpectedJdbcUrlWithProps(String scheme, String name) {
+		return String.format("jdbc:%s://%s:%d;database=%s;user=%s;password=%s;prop1=prop1;prop2=prop2",
+				scheme, hostname, port, name, UriInfo.urlEncode(username), UriInfo.urlEncode(password));
+	}
+
 	protected String getExpectedJdbcUrl(String scheme, String name, String uname, String pwd) {
 		return String.format("jdbc:%s://%s:%d;database=%s;user=%s;password=%s",
 				scheme, hostname, port, name, UriInfo.urlEncode(uname), UriInfo.urlEncode(pwd));
@@ -78,6 +113,18 @@ public class SqlServerJdbcTests extends AbstractJdbcTests {
 
 	private String getSqlserverUserProvidedServicePayload(String serviceName, String hostname, int port,
 			String user, String password, String name) {
+		return getTemplatedPayload("test-sqlserver-user-provided-info.json", serviceName,
+				hostname, port, user, password, name);
+	}
+
+	private String getSqlserverUserProvidedWithPropsServicePayload(String serviceName, String hostname, int port,
+														  String user, String password, String name) {
+		return getTemplatedPayload("test-sqlserver-user-provided-info-with-props.json", serviceName,
+				hostname, port, user, password, name);
+	}
+
+	private String getSqlserverServicePayload(String serviceName, String hostname, int port,
+														  String user, String password, String name) {
 		return getTemplatedPayload("test-sqlserver-info.json", serviceName,
 				hostname, port, user, password, name);
 	}

--- a/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-sqlserver-user-provided-info-with-props.json
+++ b/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-sqlserver-user-provided-info-with-props.json
@@ -1,0 +1,6 @@
+{
+	"name": "$serviceName",
+	"credentials": {
+		"uri": "sqlserver://$user:$password@$hostname:$port/$name?prop1=prop1&prop2=prop2"
+	}
+}

--- a/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-sqlserver-user-provided-info.json
+++ b/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-sqlserver-user-provided-info.json
@@ -1,0 +1,6 @@
+{
+	"name": "$serviceName",
+	"credentials": {
+		"uri": "sqlserver://$user:$password@$hostname:$port/$name"
+	}
+}


### PR DESCRIPTION
The SQLServer URI format of `sqlserver://username:passwordg@host:1433/database` was originally supported and then [removed](https://github.com/pivotal-cf/java-cfenv/commit/edd0068a988dda6795a68e0445ba08f23255cd8a). This change brought support for the format `sqlserver://host:1433;database=foo`.

This PR restores support for the original format which is a valid URL. It still supports the alternative format with semi-colons but because that is not a valid URL, we recommend using the original format when possible.