### PR TITLE
Remove spring boot dependency from core project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext {
+        jacksonVersion = "2.13.2.20220328"
         jmockitVersion = "1.49"
         springBootVersion = "2.6.6"
     }

--- a/java-cfenv/build.gradle
+++ b/java-cfenv/build.gradle
@@ -6,7 +6,7 @@ plugins {
 description = 'Java CF Env Core Library'
 
 dependencies {
-    api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+    api platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
     api 'com.fasterxml.jackson.core:jackson-core'
     api 'com.fasterxml.jackson.core:jackson-databind'
 


### PR DESCRIPTION
So when the `java-cfenv` library migrated to Gradle, the project began to use a Gradle platform for version alignment. The chosen platform was the `spring-boot-dependencies` BOM. While the `java-cfenv-{version}.pom` does not include any `<dependencyManagement>` section, the `java-cfenv-{version}.module` includes the platform constraint. When the library is used with a Spring project that is not aligned with the `spring-boot-dependencies` BOM platform that the project is using this results in Gradle changing the project's dependencies through it's dependency constraint in the module metadata.

The associated changes on this PR, removes the Spring Boot Dependencies BOM and instead uses the aligned Jackson BOM that is used for the current Spring Boot version. Then then changes the dependency constraint such that it will now only effect the Jackson modules, instead of a much, much larger set of dependencies.