### PR TITLE
Support boot 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '8', '11', '17' ]
     name: Java ${{ matrix.Java }} build
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         jmockitVersion = "1.49"
-        springBootVersion = "2.6.6"
+        springBootVersion = "2.6.14"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext {
         jmockitVersion = "1.49"
         springBootVersion = "2.6.14"
+        springBoot3Version = "3.0.4"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java-cfenv-boot/README.adoc
+++ b/java-cfenv-boot/README.adoc
@@ -1,0 +1,48 @@
+=== Redis
+Type: `redis`
+Disable Property: `cfenv.service.redis.enabled`
+
+==== Spring Boot 2 properties
+
+| Property                             | Value                     |
+| ------------------------------------ | ------------------------- |
+| `spring.redis.host`                  | `{host}`                  |
+| `spring.redis.password`              | `{password}`              |
+| `spring.redis.port`                  | `{port}`                  |
+| `spring.redis.ssl`                   | `{ssl}`                   |
+
+
+Not supported, compared to `spring-cloud-bindings`:
+
+| Property                             | Value                     |
+| ------------------------------------ | ------------------------- |
+| `spring.redis.client-name`           | `{client-name}`           |
+| `spring.redis.cluster.max-redirects` | `{cluster.max-redirects}` |
+| `spring.redis.cluster.nodes`         | `{cluster.nodes}`         |
+| `spring.redis.database`              | `{database}`              |
+| `spring.redis.sentinel.master`       | `{sentinel.master}`       |
+| `spring.redis.sentinel.nodes`        | `{sentinel.nodes}`        |
+| `spring.redis.url`                   | `{url}`                   |
+
+
+
+==== Spring Boot 3 properties
+
+| Property                                  | Value                     |
+|-------------------------------------------|---------------------------|
+| `spring.data.redis.host`                  | `{host}`                  |
+| `spring.data.redis.password`              | `{password}`              |
+| `spring.data.redis.port`                  | `{port}`                  |
+| `spring.data.redis.ssl`                   | `{ssl}`                   |
+
+Not supported, compared to `spring-cloud-bindings`:
+
+| Property                                  | Value                     |
+|-------------------------------------------|---------------------------|
+| `spring.data.redis.client-name`           | `{client-name}`           |
+| `spring.data.redis.cluster.max-redirects` | `{cluster.max-redirects}` |
+| `spring.data.redis.cluster.nodes`         | `{cluster.nodes}`         |
+| `spring.data.redis.database`              | `{database}`              |
+| `spring.data.redis.sentinel.master`       | `{sentinel.master}`       |
+| `spring.data.redis.sentinel.nodes`        | `{sentinel.nodes}`        |
+| `spring.data.redis.url`                   | `{url}`                   |

--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/SpringBootVersionResolver.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/SpringBootVersionResolver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+import org.springframework.boot.SpringBootVersion;
+
+/**
+ * This class is used to allow, in unit tests for example,
+ * to fake the resolution of which major version of spring boot is used
+ */
+class SpringBootVersionResolver {
+    static int forcedVersion = -1;
+
+    static boolean isBootMajorVersionEnabled(int bootVersion) {
+        if (forcedVersion != -1) {
+            return forcedVersion == bootVersion;
+        }
+        int major = Integer.parseInt(SpringBootVersion.getVersion().split("\\.")[0]);
+        return major == bootVersion;
+    }
+}

--- a/java-cfenv-boot/src/main/resources/META-INF/spring.factories
+++ b/java-cfenv-boot/src/main/resources/META-INF/spring.factories
@@ -8,11 +8,13 @@ org.springframework.context.ApplicationListener=\
   io.pivotal.cfenv.spring.boot.CfEnvironmentPostProcessor
 # CfEnvironmentPostProcessor delegates to these CfEnvProcessors for each CF service
 io.pivotal.cfenv.spring.boot.CfEnvProcessor=\
-  io.pivotal.cfenv.spring.boot.RedisCfEnvProcessor,\
+  io.pivotal.cfenv.spring.boot.RedisCfEnvProcessor.Boot2,\
+  io.pivotal.cfenv.spring.boot.RedisCfEnvProcessor.Boot3,\
   io.pivotal.cfenv.spring.boot.MongoCfEnvProcessor,\
   io.pivotal.cfenv.spring.boot.AmqpCfEnvProcessor,\
   io.pivotal.cfenv.spring.boot.CredHubCfEnvProcessor,\
-  io.pivotal.cfenv.spring.boot.CassandraCfEnvProcessor,\
+  io.pivotal.cfenv.spring.boot.CassandraCfEnvProcessor.Boot2,\
+  io.pivotal.cfenv.spring.boot.CassandraCfEnvProcessor.Boot3,\
   io.pivotal.cfenv.spring.boot.VaultCfEnvProcessor
 
 

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/CassandraCfEnvProcessorTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/CassandraCfEnvProcessorTests.java
@@ -15,7 +15,15 @@
  */
 package io.pivotal.cfenv.spring.boot;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import org.springframework.core.env.Environment;
 
@@ -28,36 +36,71 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Pollack
  * @author David Turanski
  */
+@RunWith(Parameterized.class)
 public class CassandraCfEnvProcessorTests extends AbstractCfEnvTests {
 
+	public static final String SPRING_CASSANDRA = "spring.cassandra";
+	public static final String SPRING_DATA_CASSANDRA = "spring.data.cassandra";
+
+	@Parameters(name = "SpringBoot{0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{ 2, SPRING_DATA_CASSANDRA, new CassandraCfEnvProcessor.Boot2()}, { 3, SPRING_CASSANDRA, new CassandraCfEnvProcessor.Boot3()}
+		});
+	}
+
+	@Parameter
+	public int springBootVersion;
+
+	@Parameter(1)
+	public String configurationPrefix;
+
+	@Parameter(2)
+	public CfEnvProcessor versionSpecificCassandraCfEnvProcessor;
+
+	@After
+	public void resetSpringBootVersion() {
+		SpringBootVersionResolver.forcedVersion = -1;
+	}
+	
 	@Test
 	public void simpleService() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		mockVcapServicesWithNames("io/pivotal/cfenv/spring/boot/test-cassandra-service.json");
 		Environment environment = getEnvironment();
-		assertThat(environment.getProperty("spring.data.cassandra.username")).isNull();
-		assertThat(environment.getProperty("spring.data.cassandra.password")).isNull();
-		assertThat(environment.getProperty("spring.data.cassandra.port")).isEqualTo("9042");
-		assertThat(environment.getProperty("spring.data.cassandra.contact-points")).contains("1.2.3.4","5.6.7.8");
+		assertThat(environment.getProperty(configurationPrefix + ".username")).isNull();
+		assertThat(environment.getProperty(configurationPrefix + ".password")).isNull();
+		assertThat(environment.getProperty(configurationPrefix + ".port")).isEqualTo("9042");
+		assertThat(environment.getProperty(configurationPrefix + ".contact-points")).contains("1.2.3.4","5.6.7.8");
 	}
 
 	@Test
 	public void simpleServiceUserNamePassword() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		mockVcapServicesWithNames("io/pivotal/cfenv/spring/boot/test-cassandra-with-credentials.json");
 		Environment environment = getEnvironment();
-		assertThat(environment.getProperty("spring.data.cassandra.username")).isEqualTo("user");
-		assertThat(environment.getProperty("spring.data.cassandra.password")).isEqualTo("pass");
-		assertThat(environment.getProperty("spring.data.cassandra.port")).isEqualTo("9042");
-		assertThat(environment.getProperty("spring.data.cassandra.contact-points")).contains("1.2.3.4");
+		assertThat(environment.getProperty(configurationPrefix + ".username")).isEqualTo("user");
+		assertThat(environment.getProperty(configurationPrefix + ".password")).isEqualTo("pass");
+		assertThat(environment.getProperty(configurationPrefix + ".port")).isEqualTo("9042");
+		assertThat(environment.getProperty(configurationPrefix + ".contact-points")).contains("1.2.3.4");
 	}
 
 	@Test
 	public void serviceNotValid() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		mockVcapServicesWithNames("io/pivotal/cfenv/spring/boot/test-cassandra-missing-required-fields.json");
 		Environment environment = getEnvironment();
-		assertThat(environment.getProperty("spring.data.cassandra.username")).isNull();
-		assertThat(environment.getProperty("spring.data.cassandra.password")).isNull();
-		assertThat(environment.getProperty("spring.data.cassandra.port")).isNull();
-		assertThat(environment.getProperty("spring.data.cassandra.contact-points")).isNull();
+		assertThat(environment.getProperty(configurationPrefix + ".username")).isNull();
+		assertThat(environment.getProperty(configurationPrefix + ".password")).isNull();
+		assertThat(environment.getProperty(configurationPrefix + ".port")).isNull();
+		assertThat(environment.getProperty(configurationPrefix + ".contact-points")).isNull();
+	}
+
+	@Test
+	public void testGetProperties() {
+		assertThat(versionSpecificCassandraCfEnvProcessor.getProperties().getPropertyPrefixes()).isEqualTo(configurationPrefix);
+		assertThat(versionSpecificCassandraCfEnvProcessor.getProperties().getServiceName()).isEqualTo("Cassandra");
+
 	}
 
 	private void mockVcapServicesWithNames(String fileName) {

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessorTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessorTests.java
@@ -15,7 +15,15 @@
  */
 package io.pivotal.cfenv.spring.boot;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import org.springframework.core.env.Environment;
 
@@ -27,25 +35,51 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Pollack
  * @author David Turanski
  */
+@RunWith(Parameterized.class)
 public class RedisCfEnvProcessorTests extends AbstractCfEnvTests {
 	private final static int TLS_PORT = 11111;
+	public static final String SPRING_REDIS = "spring.redis";
+	public static final String SPRING_DATA_REDIS = "spring.data.redis";
 
-	public static void commonAssertions(Environment environment) {
-		assertThat(environment.getProperty("spring.redis.host")).isEqualTo(hostname);
-		assertThat(environment.getProperty("spring.redis.port")).isEqualTo(String.valueOf(port));
-		assertThat(environment.getProperty("spring.redis.password")).isEqualTo(password);
+	public static void commonAssertions(Environment environment, String configurationPrefix) {
+		assertThat(environment.getProperty(configurationPrefix + ".host")).isEqualTo(hostname);
+		assertThat(environment.getProperty(configurationPrefix + ".port")).isEqualTo(String.valueOf(port));
+		assertThat(environment.getProperty(configurationPrefix + ".password")).isEqualTo(password);
 	}
+
+	@Parameters(name = "SpringBoot{0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{ 2, SPRING_REDIS, new RedisCfEnvProcessor.Boot2()}, { 3, SPRING_DATA_REDIS, new RedisCfEnvProcessor.Boot3()}
+		});
+	}
+
+	@Parameter
+	public int springBootVersion;
+
+	@Parameter(1)
+	public String configurationPrefix;
+
+	@Parameter(2)
+	public CfEnvProcessor versionSpecificRedisCfEnvProcessor;
+
+    @After
+    public void resetSpringBootVersion() {
+        SpringBootVersionResolver.forcedVersion = -1;
+    }
 
 	@Test
 	public void testRedisBootPropertiesWithoutUriInCredentials() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		String payload = payloadBuilder("test-redis-info.json").payload();
 		mockVcapServices(getServicesPayload(payload));
 
-		commonAssertions(getEnvironment());
+        commonAssertions(getEnvironment(), configurationPrefix);
 	}
 
 	@Test
 	public void testRedisBootPropertiesWithTLSEnabledInCredentials() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		String payload = payloadBuilder("test-redis-info-with-tls-port.json")
 				.withTLSPort(TLS_PORT)
 				.payload();
@@ -53,33 +87,42 @@ public class RedisCfEnvProcessorTests extends AbstractCfEnvTests {
 
 		Environment environment = getEnvironment();
 
-		assertThat(environment.getProperty("spring.redis.host")).isEqualTo(hostname);
-		assertThat(environment.getProperty("spring.redis.port")).isEqualTo(String.valueOf(TLS_PORT));
-		assertThat(environment.getProperty("spring.redis.password")).isEqualTo(password);
-		assertThat(environment.getProperty("spring.redis.ssl")).isEqualTo("true");
+		assertThat(environment.getProperty(configurationPrefix+".host")).isEqualTo(hostname);
+		assertThat(environment.getProperty(configurationPrefix+".port")).isEqualTo(String.valueOf(TLS_PORT));
+		assertThat(environment.getProperty(configurationPrefix+".password")).isEqualTo(password);
+		assertThat(environment.getProperty(configurationPrefix+".ssl")).isEqualTo("true");
 	}
 
 	@Test
 	public void testRedisSSlBootPropertiesWithUriInCredentials() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		String payload = payloadBuilder("test-redis-info-no-label-no-tags-secure.json").payload();
 		mockVcapServices(getServicesPayload(payload));
 
 		Environment environment = getEnvironment();
-		commonAssertions(environment);
-		assertThat(environment.getProperty("spring.redis.ssl")).isEqualTo("true");
+		commonAssertions(getEnvironment(), configurationPrefix);
+		assertThat(environment.getProperty(configurationPrefix+".ssl")).isEqualTo("true");
 	}
 
 	@Test
 	public void testNoCredentials() {
+		SpringBootVersionResolver.forcedVersion = springBootVersion;
 		String payload = "{}";
 		mockVcapServices(getServicesPayload(payload));
 
 		Environment environment = getEnvironment();
 
-		assertThat(environment.getProperty("spring.redis.host")).isNull();
-		assertThat(environment.getProperty("spring.redis.port")).isNull();
-		assertThat(environment.getProperty("spring.redis.password")).isNull();
-		assertThat(environment.getProperty("spring.redis.ssl")).isNull();
+		assertThat(environment.getProperty(configurationPrefix+".host")).isNull();
+		assertThat(environment.getProperty(configurationPrefix+".port")).isNull();
+		assertThat(environment.getProperty(configurationPrefix+".password")).isNull();
+		assertThat(environment.getProperty(configurationPrefix+".ssl")).isNull();
+	}
+
+	@Test
+	public void testGetProperties() {
+		assertThat(versionSpecificRedisCfEnvProcessor.getProperties().getPropertyPrefixes()).isEqualTo(configurationPrefix);
+		assertThat(versionSpecificRedisCfEnvProcessor.getProperties().getServiceName()).isEqualTo("Redis");
+
 	}
 
 	private RedisFilePayloadBuilder payloadBuilder(String filename) {

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/SpringBootVersionResolverTest.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/SpringBootVersionResolverTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBootVersionResolverTest {
+
+    @Test
+    public void testIsBootMajorVersionEnabledDefault() {
+        assertThat(SpringBootVersionResolver.isBootMajorVersionEnabled(2)).isEqualTo(true);
+    }
+
+    @Test
+    public void testIsBootMajorVersionEnabledForced() {
+        SpringBootVersionResolver.forcedVersion = 3;
+        assertThat(SpringBootVersionResolver.isBootMajorVersionEnabled(3)).isEqualTo(true);
+    }
+
+    @After
+    public void resetForcedVersion() {
+        SpringBootVersionResolver.forcedVersion = -1;
+    }
+}

--- a/java-cfenv-tests-boot-2/build.gradle
+++ b/java-cfenv-tests-boot-2/build.gradle
@@ -1,0 +1,30 @@
+buildscript {
+    ext {
+        springBootVersion = "2.6.14"
+    }
+}
+
+plugins {
+    id 'io.pivotal.cfenv.java-conventions'
+}
+
+description = 'Java CF Env Spring Boot 2 specific tests'
+
+dependencies {
+    testImplementation project(':java-cfenv-boot')
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'com.github.kstyrc:embedded-redis:0.6'
+
+    testImplementation "junit:junit"
+
+    testRuntimeOnly('org.junit.vintage:junit-vintage-engine') {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+}
+
+tasks.withType(Test) {
+    environment 'VCAP_SERVICES', '{"p-redis":[{"label":"p-redis","provider":null,"plan":"shared-vm","name":"my-redis-service","tags":["pivotal","redis"],"instance_guid":"cde54916-a366-4028-a2ec-1d5dc9657c68","instance_name":"my-redis-service","binding_guid":"8f81d232-25f3-4002-a012-1f734b464bc6","binding_name":null,"credentials":{"host":"localhost","password":"","port":46083},"syslog_drain_url":null,"volume_mounts":[]}]}'
+}
+

--- a/java-cfenv-tests-boot-2/src/test/java/io/pivotal/cfenv/spring/boot/IntegrationTest.java
+++ b/java-cfenv-tests-boot-2/src/test/java/io/pivotal/cfenv/spring/boot/IntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+
+@SpringBootTest(classes = RedisServerTestConfiguration.class)
+public class IntegrationTest {
+
+	@Autowired
+	private RedisTemplate redisTemplate;
+
+	@Test
+	public void shouldSaveUser_toRedis() {
+		redisTemplate.opsForValue().set("hello", "world");
+		Assertions.assertTrue(redisTemplate.hasKey("hello"));
+	}
+}

--- a/java-cfenv-tests-boot-2/src/test/java/io/pivotal/cfenv/spring/boot/RedisServerTestConfiguration.java
+++ b/java-cfenv-tests-boot-2/src/test/java/io/pivotal/cfenv/spring/boot/RedisServerTestConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+
+import java.io.IOException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import redis.embedded.RedisServer;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+
+@TestConfiguration
+public class RedisServerTestConfiguration {
+
+    private final RedisServer redisServer;
+
+    // this port needs to match the on found in VCAP_SERVICES in build.gradle
+    private final static int PORT = 46083;
+
+    public RedisServerTestConfiguration() throws IOException {
+        this.redisServer = new RedisServer(PORT);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        redisServer.stop();
+    }
+}

--- a/java-cfenv-tests-boot-2/src/test/java/io/pivotal/cfenv/spring/boot/SpringBoot2Application.java
+++ b/java-cfenv-tests-boot-2/src/test/java/io/pivotal/cfenv/spring/boot/SpringBoot2Application.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringBoot2Application {
+}

--- a/java-cfenv-tests-boot-3/build.gradle
+++ b/java-cfenv-tests-boot-3/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'io.pivotal.cfenv.java-conventions'
+}
+
+description = 'Java CF Env Spring Boot 3 specific tests'
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+
+dependencies {
+    testImplementation project(':java-cfenv-boot')
+
+    testImplementation "org.springframework.boot:spring-boot-starter-test:${springBoot3Version}"
+    testImplementation "org.springframework.boot:spring-boot-starter-data-redis:${springBoot3Version}"
+    testImplementation 'com.github.kstyrc:embedded-redis:0.6'
+
+    testImplementation "junit:junit"
+
+    testRuntimeOnly('org.junit.vintage:junit-vintage-engine') {
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+}
+
+tasks.withType(Test) {
+    environment 'VCAP_SERVICES', '{"p-redis":[{"label":"p-redis","provider":null,"plan":"shared-vm","name":"my-redis-service","tags":["pivotal","redis"],"instance_guid":"cde54916-a366-4028-a2ec-1d5dc9657c68","instance_name":"my-redis-service","binding_guid":"8f81d232-25f3-4002-a012-1f734b464bc6","binding_name":null,"credentials":{"host":"localhost","password":"","port":46084},"syslog_drain_url":null,"volume_mounts":[]}]}'
+}
+

--- a/java-cfenv-tests-boot-3/src/test/java/io/pivotal/cfenv/spring/boot/IntegrationTest.java
+++ b/java-cfenv-tests-boot-3/src/test/java/io/pivotal/cfenv/spring/boot/IntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest(classes = RedisServerTestConfiguration.class)
+public class IntegrationTest {
+
+	@Autowired
+	private RedisTemplate redisTemplate;
+
+	@Test
+	public void shouldSaveUser_toRedis() {
+		redisTemplate.opsForValue().set("hello", "world");
+		Assertions.assertTrue(redisTemplate.hasKey("hello"));
+	}
+}

--- a/java-cfenv-tests-boot-3/src/test/java/io/pivotal/cfenv/spring/boot/RedisServerTestConfiguration.java
+++ b/java-cfenv-tests-boot-3/src/test/java/io/pivotal/cfenv/spring/boot/RedisServerTestConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+
+import java.io.IOException;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import redis.embedded.RedisServer;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+public class RedisServerTestConfiguration {
+
+    private final RedisServer redisServer;
+
+    // this port needs to match the on found in VCAP_SERVICES in build.gradle
+    private final static int PORT = 46084;
+
+    public RedisServerTestConfiguration() throws IOException {
+        this.redisServer = new RedisServer(PORT);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        redisServer.stop();
+    }
+}

--- a/java-cfenv-tests-boot-3/src/test/java/io/pivotal/cfenv/spring/boot/SpringBoot3Application.java
+++ b/java-cfenv-tests-boot-3/src/test/java/io/pivotal/cfenv/spring/boot/SpringBoot3Application.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.cfenv.spring.boot;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringBoot3Application {
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,8 @@ rootProject.name = 'java-cfenv'
 
 include "java-cfenv"
 include "java-cfenv-boot"
+include "java-cfenv-tests-boot-2"
+include "java-cfenv-tests-boot-3"
 include "java-cfenv-boot-pivotal-scs"
 include "java-cfenv-boot-pivotal-sso"
 //include "java-cfenv-docs"


### PR DESCRIPTION
This is an initial PR

* [X] Spring Boot 3 Redis configuration (`spring.data.redis`) is now supported (maintaining SB 2 compatibility)
* [X] Tested with a sample SB3 project with a Redis service in Cloud Foundry TAS 3

```
[...]
   2023-03-15T16:57:17.64-0400 [APP/PROC/WEB/0] OUT :: Spring Boot ::                (v3.0.4)
   2023-03-15T16:57:18.03-0400 [APP/PROC/WEB/0] OUT 2023-03-15T20:57:18.027Z  INFO 7 --- [           main] o.s.c.SpringBootServiceProberApplication : Starting SpringBootServiceProberApplication v1.0.2-SNAPSHOT using Java 17.0.6 with PID 7 (/home/vcap/app/BOOT-INF/classes started by vcap in /home/vcap/app)
[...]
   2023-03-15T16:57:18.17-0400 [APP/PROC/WEB/0] OUT 2023-03-15T20:57:18.177Z  INFO 7 --- [           main] i.p.c.s.boot.CfEnvironmentPostProcessor  : Setting spring.data.redis properties from bound service [my-redis-service] using io.pivotal.cfenv.spring.boot.RedisCfEnvProcessor$Boot3
[...]
  org.springframework.cloud.RedisProber    : We could connect to Redis successfully to this URI: redis://************************************@10.0.8.36:46083
o.s.c.SpringBootServiceProberApplication : Started SpringBootServiceProberApplication in 11.199 seconds (process running for 12.755)
```

* [x] other services need to be supported : Cassandra from [`spring.data.cassandra` to `spring.cassandra`](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#cassandra-properties)
* [x] integration tests in Spring Boot 2 and Spring Boot 3 sample projects need to be added