### PR TITLE
Fix #231: remove url encoding for DB2

### DIFF
--- a/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/DB2JdbcUrlCreator.java
+++ b/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/DB2JdbcUrlCreator.java
@@ -47,7 +47,7 @@ public class DB2JdbcUrlCreator extends AbstractJdbcUrlCreator  {
 		UriInfo uriInfo = cfCredentials.getUriInfo(DB2_SCHEME);
 		return String.format("jdbc:%s://%s:%d/%s:user=%s;password=%s;",
 				DB2_SCHEME, uriInfo.getHost(), uriInfo.getPort(), uriInfo.getPath(),
-				UriInfo.urlEncode(uriInfo.getUsername()), UriInfo.urlEncode(uriInfo.getPassword()));
+				uriInfo.getUsername(), uriInfo.getPassword());
 	}
 
 

--- a/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/DB2JdbcTests.java
+++ b/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/DB2JdbcTests.java
@@ -123,6 +123,6 @@ public class DB2JdbcTests extends AbstractJdbcTests {
 
 	protected String getExpectedJdbcUrl(String scheme, String name, String uname, String pwd) {
 		return String.format("jdbc:%s://%s:%d/%s:user=%s;password=%s;",
-				DB2JdbcUrlCreator.DB2_SCHEME, hostname, port, name, UriInfo.urlEncode(uname), UriInfo.urlEncode(pwd));
+				DB2JdbcUrlCreator.DB2_SCHEME, hostname, port, name, uname, pwd);
 	}
 }


### PR DESCRIPTION
* so that username and password are properly transmitted to the drive
* provide same behavior as Spring SAR/ SCS connector: https://github.com/spring-cloud/spring-cloud-connectors/commit/a8eef2bdcbb5f177791d3843e2502db4c4dc32d8