### PR TITLE
(main) Apply a resolutionStrategy to avoid Asciidoctor Gradle version multiple times

### DIFF
--- a/java-cfenv-docs/build.gradle
+++ b/java-cfenv-docs/build.gradle
@@ -6,20 +6,15 @@ plugins {
 description = 'Java CF Env Documentation'
 
 configurations {
-    docs
+    asciidoctorExtensions
 }
 
 dependencies {
-    docs "io.spring.docresources:spring-doc-resources:0.2.5@zip"
+    asciidoctorExtensions "io.spring.asciidoctor.backends:spring-asciidoctor-backends:0.0.7"
 }
 
 task prepareAsciidocBuild(type: Sync) {
-    dependsOn configurations.docs
-    // copy doc resources
-    from {
-        configurations.docs.collect { zipTree(it) }
-    }
-    // and doc sources
+    // Copy doc sources
     from "src/main/asciidoc"
     // to a temporary build directory
     into "$buildDir/asciidoc"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,15 @@
 pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.namespace?.startsWith('org.asciidoctor.jvm')) {
+                useVersion("4.0.3")
+            }
+        }
+    }
     plugins {
         id "io.spring.nohttp" version "0.0.11"
-        id 'org.asciidoctor.jvm.pdf' version '4.0.3'
-        id 'org.asciidoctor.jvm.convert' version '4.0.3'
+        id 'org.asciidoctor.jvm.pdf'
+        id 'org.asciidoctor.jvm.convert'
     }
 }
 


### PR DESCRIPTION
The main goal is to avoid multiple Dependabot PRs when there's a new Asciidoctor Gradle release.
Additionally, fixes the docs project configuration, even though I see the module is not included and the docs are empty.