### PR TITLE
Fix ssl enabled property in Redis config for Spring Boot 3.1

### DIFF
--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessor.java
@@ -58,7 +58,7 @@ public class RedisCfEnvProcessor implements CfEnvProcessor {
 			Optional<String> tlsPort = Optional.ofNullable(cfCredentials.getString("tls_port"));
 			if (tlsPort.isPresent()) {
 				properties.put(PREFIX + ".port", tlsPort.get());
-				properties.put(PREFIX + ".ssl", "true");
+				properties.put(PREFIX + ".ssl.enabled", "true");
 			} else {
 				properties.put(PREFIX + ".port", cfCredentials.getPort());
 			}
@@ -68,7 +68,7 @@ public class RedisCfEnvProcessor implements CfEnvProcessor {
 			properties.put(PREFIX + ".port", uriInfo.getPort());
 			properties.put(PREFIX + ".password", uriInfo.getPassword());
 			if (uriInfo.getScheme().equals("rediss")) {
-				properties.put(PREFIX + ".ssl", "true");
+				properties.put(PREFIX + ".ssl.enabled", "true");
 			}
 		}
 	}

--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessor.java
@@ -58,7 +58,7 @@ public class RedisCfEnvProcessor implements CfEnvProcessor {
 			Optional<String> tlsPort = Optional.ofNullable(cfCredentials.getString("tls_port"));
 			if (tlsPort.isPresent()) {
 				properties.put(PREFIX + ".port", tlsPort.get());
-				properties.put(PREFIX + ".ssl.enabled", "true");
+				properties.put(PREFIX + ".ssl.enabled", Boolean.TRUE);
 			} else {
 				properties.put(PREFIX + ".port", cfCredentials.getPort());
 			}
@@ -68,7 +68,7 @@ public class RedisCfEnvProcessor implements CfEnvProcessor {
 			properties.put(PREFIX + ".port", uriInfo.getPort());
 			properties.put(PREFIX + ".password", uriInfo.getPassword());
 			if (uriInfo.getScheme().equals("rediss")) {
-				properties.put(PREFIX + ".ssl.enabled", "true");
+				properties.put(PREFIX + ".ssl.enabled", Boolean.TRUE);
 			}
 		}
 	}

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessorTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/RedisCfEnvProcessorTests.java
@@ -57,7 +57,7 @@ public class RedisCfEnvProcessorTests extends AbstractCfEnvTests {
 		assertThat(environment.getProperty(SPRING_DATA_REDIS + ".host")).isEqualTo(hostname);
 		assertThat(environment.getProperty(SPRING_DATA_REDIS + ".port")).isEqualTo(String.valueOf(TLS_PORT));
 		assertThat(environment.getProperty(SPRING_DATA_REDIS + ".password")).isEqualTo(password);
-		assertThat(environment.getProperty(SPRING_DATA_REDIS + ".ssl")).isEqualTo("true");
+		assertThat(environment.getProperty(SPRING_DATA_REDIS + ".ssl.enabled")).isEqualTo("true");
 	}
 
 	@Test
@@ -67,7 +67,7 @@ public class RedisCfEnvProcessorTests extends AbstractCfEnvTests {
 
 		Environment environment = getEnvironment();
 		commonAssertions(getEnvironment(), SPRING_DATA_REDIS);
-		assertThat(environment.getProperty(SPRING_DATA_REDIS+".ssl")).isEqualTo("true");
+		assertThat(environment.getProperty(SPRING_DATA_REDIS+".ssl.enabled")).isEqualTo("true");
 	}
 
 	@Test


### PR DESCRIPTION
In Srping Boot 3.1, the flag is ssl.enbled not ssl, as in the java doc here: https://docs.spring.io/spring-boot/docs/3.1.8/api/org/springframework/boot/autoconfigure/data/redis/RedisProperties.Ssl.html#isEnabled()