### PR TITLE
Arrange assertion

### DIFF
--- a/buildSrc/src/main/groovy/io.pivotal.cfenv.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.pivotal.cfenv.java-conventions.gradle
@@ -162,7 +162,12 @@ publishing {
                     if (project.name == 'java-cfenv-test-support') {
                         def cfenvDependencies = pomNode.get('dependencies')[0].findAll { it.get('artifactId')[0].text() == 'java-cfenv' }
                         assert cfenvDependencies.size() == 1
+                        def clone = cfenvDependencies[0].clone()
+                        // see https://github.com/pivotal-cf/java-cfenv/pull/264#issuecomment-2105127180
                         cfenvDependencies[0].appendNode('type', "test-jar")
+                        pomNode.get('dependencies')[0].children().add(0, clone)
+                        cfenvDependencies = pomNode.get('dependencies')[0].findAll { it.get('artifactId')[0].text() == 'java-cfenv' }
+                        assert cfenvDependencies.size() == 2
                     }
                 }
             }

--- a/buildSrc/src/main/groovy/io.pivotal.cfenv.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.pivotal.cfenv.java-conventions.gradle
@@ -161,8 +161,8 @@ publishing {
 
                     if (project.name == 'java-cfenv-test-support') {
                         def cfenvDependencies = pomNode.get('dependencies')[0].findAll { it.get('artifactId')[0].text() == 'java-cfenv' }
-                        assert cfenvDependencies.size() == 2
-                        cfenvDependencies[1].appendNode('type', "test-jar")
+                        assert cfenvDependencies.size() == 1
+                        cfenvDependencies[0].appendNode('type', "test-jar")
                     }
                 }
             }


### PR DESCRIPTION
* generated dependencies in pom have changed

With 
```
./gradlew clean :java-cfenv-test-support:generatePomFileForMavenJavaPublication
```

Before (assert 2):
```
<dependencies>
        <dependency>
            <groupId>io.pivotal.cfenv</groupId>
            <artifactId>java-cfenv</artifactId>
            <version>3.1.6-SNAPSHOT</version>
            <scope>compile</scope>
        </dependency>
        <dependency>
            <groupId>io.pivotal.cfenv</groupId>
            <artifactId>java-cfenv</artifactId>
            <version>3.1.6-SNAPSHOT</version>
            <scope>compile</scope>
            <type>test-jar</type>
        </dependency>
[...]
</dependencies>
```

after (assert 1):

```
<dependencies>
    <dependency>
      <groupId>io.pivotal.cfenv</groupId>
      <artifactId>java-cfenv</artifactId>
      <version>3.1.6-SNAPSHOT</version>
      <scope>compile</scope>
      <type>test-jar</type>
    </dependency>
</dependencies>
```

It's as if Gradle "optimized" the 2 deps into 1 -  for most probably (I'm gonna find out) the same classpath result in Maven