### PR TITLE
Greg main - replaces  Support for R2DBC connections in DataSource processor. #262 

### DIFF
--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
@@ -15,6 +15,8 @@
  */
 package io.pivotal.cfenv.spring.boot;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,7 @@ import io.pivotal.cfenv.jdbc.CfJdbcService;
 /**
  * @author Mark Pollack
  * @author David Turanski
+ * @author Greg Meyer
  */
 public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEnvironmentPostProcessor,
 		Ordered, ApplicationListener<ApplicationEvent> {
@@ -46,6 +49,16 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 
 	private static int invocationCount;
 
+    /**
+     * MySQL connection protocol constant.
+     */
+    private static final String MYSQL_PROTOCOL = "mysql";
+    
+    /**
+     *  MariaDB connection protocol constant. 
+     */
+    private static final String MARIADB_PROTOCOL = "mariadb";
+	
 	// After ConfigFileApplicationListener so values from files can be used here
 	private int order = ConfigDataEnvironmentPostProcessor.ORDER + 1;
 
@@ -95,6 +108,42 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 				if (driverClassName != null) {
 					properties.put("spring.datasource.driver-class-name", driverClassName);
 				}
+				
+				/* R2DBC processing
+				 * Split query param options and URL into two string
+				 * and move options to spring.r2dbc.properties.<option>
+				 */
+				
+				String[] splitJDBCUrl = cfJdbcService.getJdbcUrl().split("\\?");
+				
+				String r2dbcUrl = splitJDBCUrl[0].replaceFirst("jdbc:", "r2dbc:");
+				
+				// Case for MySQL where Maria DB protocol may be required
+				if (r2dbcUrl.contains(MYSQL_PROTOCOL))
+					r2dbcUrl = r2dbcUrl.replaceFirst(MYSQL_PROTOCOL, evalMySQLProtocol());
+				
+				properties.put("spring.r2dbc.url", r2dbcUrl);
+				properties.put("spring.r2dbc.username", cfJdbcService.getUsername());
+				properties.put("spring.r2dbc.password", cfJdbcService.getPassword());				
+				
+				if (splitJDBCUrl.length == 2)
+				{
+					Map<String, String> queryOptions = parseQueryString(splitJDBCUrl[1]); 
+					
+					if (queryOptions.size() > 0) {
+						queryOptions.forEach((key, value) -> {
+							
+							switch (key)
+							{						
+								case "enabledTLSProtocols":
+									properties.put("spring.r2dbc.properties.tlsVersion", value);
+									break;		
+								default:
+									properties.put(String.format("spring.r2dbc.properties.%s", key) , value);
+							}
+						});
+					};
+				}
 
 				MutablePropertySources propertySources = environment.getPropertySources();
 				if (propertySources.contains(
@@ -120,6 +169,49 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 		}
 	}
 
+    private String evalMySQLProtocol()
+    {
+    	// Default to "mysql"
+    	String connectionProtocol = MYSQL_PROTOCOL;
+    	
+    	/* In Spring Boot 2.7.0, the previous MySQL r2dbc driver is no longer supported and 
+    	 * documentation suggests using the MariaDB R2DBC driver as an alternative.  Some versions
+    	 * of the MariaDB R2DBC driver do not support "mysql" as part of the connection
+    	 * protocol; "mariadb" should be used instead when the MariaDB R2DBC driver class is on
+    	 * the classpath.
+    	 */
+    	
+    	try {
+    		Class.forName("org.mariadb.r2dbc.MariadbConnection");
+    		connectionProtocol = MARIADB_PROTOCOL;
+    	}
+    	catch (ClassNotFoundException ignored) {
+        }
+    	
+    	return connectionProtocol; 
+    }	
+	
+	private Map<String, String> parseQueryString(String queryParams) {
+		
+		if (queryParams == null || queryParams.equals(""))
+			return Collections.emptyMap(); 
+		
+		Map<String, String> retVal = new HashMap<>();
+		
+		String[] options = queryParams.split("&");
+		for (String option : options) {
+			
+			String[] keyval = option.split("=");
+            if (keyval.length != 2 || keyval[0].length() == 0 || keyval[1].length() == 0) {
+                continue;
+            }
+            
+            retVal.put(keyval[0], keyval[1]);
+		}
+		
+		return retVal;
+	}
+	
 	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
 		if (event instanceof ApplicationPreparedEvent) {

--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
@@ -49,15 +49,15 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 
 	private static int invocationCount;
 
-    /**
-     * MySQL connection protocol constant.
-     */
-    private static final String MYSQL_PROTOCOL = "mysql";
+	/**
+	* MySQL connection protocol constant.
+	*/
+	private static final String MYSQL_PROTOCOL = "mysql";
     
-    /**
-     *  MariaDB connection protocol constant. 
-     */
-    private static final String MARIADB_PROTOCOL = "mariadb";
+	/**
+ 	*  MariaDB connection protocol constant. 
+ 	*/
+	private static final String MARIADB_PROTOCOL = "mariadb";
 	
 	// After ConfigFileApplicationListener so values from files can be used here
 	private int order = ConfigDataEnvironmentPostProcessor.ORDER + 1;
@@ -169,27 +169,27 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 		}
 	}
 
-    private String evalMySQLProtocol()
-    {
-    	// Default to "mysql"
-    	String connectionProtocol = MYSQL_PROTOCOL;
+	private String evalMySQLProtocol()
+	{
+		// Default to "mysql"
+    		String connectionProtocol = MYSQL_PROTOCOL;
     	
-    	/* In Spring Boot 2.7.0, the previous MySQL r2dbc driver is no longer supported and 
-    	 * documentation suggests using the MariaDB R2DBC driver as an alternative.  Some versions
-    	 * of the MariaDB R2DBC driver do not support "mysql" as part of the connection
-    	 * protocol; "mariadb" should be used instead when the MariaDB R2DBC driver class is on
-    	 * the classpath.
-    	 */
+ 		/* In Spring Boot 2.7.0, the previous MySQL r2dbc driver is no longer supported and 
+		* documentation suggests using the MariaDB R2DBC driver as an alternative.  Some versions
+		* of the MariaDB R2DBC driver do not support "mysql" as part of the connection
+		* protocol; "mariadb" should be used instead when the MariaDB R2DBC driver class is on
+		* the classpath.
+		*/
     	
-    	try {
-    		Class.forName("org.mariadb.r2dbc.MariadbConnection");
-    		connectionProtocol = MARIADB_PROTOCOL;
-    	}
-    	catch (ClassNotFoundException ignored) {
-        }
+		try {
+			Class.forName("org.mariadb.r2dbc.MariadbConnection");
+			connectionProtocol = MARIADB_PROTOCOL;
+		}
+		catch (ClassNotFoundException ignored) {
+ 		}
     	
-    	return connectionProtocol; 
-    }	
+		return connectionProtocol; 
+	}	
 	
 	private Map<String, String> parseQueryString(String queryParams) {
 		
@@ -202,11 +202,11 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 		for (String option : options) {
 			
 			String[] keyval = option.split("=");
-            if (keyval.length != 2 || keyval[0].length() == 0 || keyval[1].length() == 0) {
-                continue;
-            }
+			if (keyval.length != 2 || keyval[0].length() == 0 || keyval[1].length() == 0) {
+				continue;
+			}
             
-            retVal.put(keyval[0], keyval[1]);
+ 			retVal.put(keyval[0], keyval[1]);
 		}
 		
 		return retVal;

--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/CfDataSourceEnvironmentPostProcessor.java
@@ -172,15 +172,14 @@ public class CfDataSourceEnvironmentPostProcessor implements CfServiceEnablingEn
 	private String evalMySQLProtocol()
 	{
 		// Default to "mysql"
-    		String connectionProtocol = MYSQL_PROTOCOL;
+		String connectionProtocol = MYSQL_PROTOCOL;
     	
- 		/* In Spring Boot 2.7.0, the previous MySQL r2dbc driver is no longer supported and 
-		* documentation suggests using the MariaDB R2DBC driver as an alternative.  Some versions
-		* of the MariaDB R2DBC driver do not support "mysql" as part of the connection
-		* protocol; "mariadb" should be used instead when the MariaDB R2DBC driver class is on
-		* the classpath.
-		*/
-    	
+		/* In Spring Boot 2.7.0, the previous MySQL r2dbc driver is no longer supported and 
+		 * documentation suggests using the MariaDB R2DBC driver as an alternative.  Some versions
+		 * of the MariaDB R2DBC driver do not support "mysql" as part of the connection
+		 * protocol; "mariadb" should be used instead when the MariaDB R2DBC driver class is on the classpath.
+    	 */
+		
 		try {
 			Class.forName("org.mariadb.r2dbc.MariadbConnection");
 			connectionProtocol = MARIADB_PROTOCOL;

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/DataSourceTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/DataSourceTests.java
@@ -72,7 +72,7 @@ public class DataSourceTests extends AbstractCfEnvTests {
 				this.context.getEnvironment().getProperty("spring.r2dbc.username"))
 				.isEqualTo("mysql_username");
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.password"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.password"))
 				.isEqualTo("mysql_password");		
 
 		} finally {
@@ -110,31 +110,31 @@ public class DataSourceTests extends AbstractCfEnvTests {
 				this.context.getEnvironment().getProperty("spring.r2dbc.username"))
 				.isEqualTo("mysql_username");
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.password"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.password"))
 				.isEqualTo("mysql_password");		
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.user"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.user"))
 				.isEqualTo("mysql_username");		
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.password"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.password"))
 				.isEqualTo("mysql_password");	
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.sslMode"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.sslMode"))
 				.isEqualTo("VERIFY_IDENTITY");				
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.useSSL"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.useSSL"))
 				.isEqualTo("true");				
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.requireSSL"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.requireSSL"))
 				.isEqualTo("true");		
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.tlsVersion"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.tlsVersion"))
 				.isEqualTo("TLSv1.2");				
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.serverSslCert"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.serverSslCert"))
 				.isEqualTo("/etc/ssl/certs/ca-certificates.crt");
 			assertThat(
-					this.context.getEnvironment().getProperty("spring.r2dbc.properties.serverSslCert"))
+				this.context.getEnvironment().getProperty("spring.r2dbc.properties.serverSslCert"))
 				.isEqualTo("/etc/ssl/certs/ca-certificates.crt");			
 			
 		} finally {

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/DataSourceTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/DataSourceTests.java
@@ -30,11 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Mark Pollack
+ * @author Greg Meyer
  */
 public class DataSourceTests extends AbstractCfEnvTests {
 
 	private static final String mysqlJdbcUrl = "jdbc:mysql://10.0.4.35:3306/cf_2e23d10a_8738_8c3c_66cf_13e44422698c?user=mysql_username&password=mysql_password";
 
+	private static final String tlsMysqlJdbcUrl = "jdbc:mysql://10.0.4.35:3306/service_instance_db?permitMysqlScheme&user=mysql_username&password=mysql_password&sslMode=VERIFY_IDENTITY&useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2&serverSslCert=/etc/ssl/certs/ca-certificates.crt";
+	
 	private final CfDataSourceEnvironmentPostProcessor environmentPostProcessor = new CfDataSourceEnvironmentPostProcessor();
 
 	private final ConfigurableApplicationContext context = new AnnotationConfigApplicationContext();
@@ -62,9 +65,80 @@ public class DataSourceTests extends AbstractCfEnvTests {
 			assertThat(
 					this.context.getEnvironment().getProperty("spring.datasource.password"))
 					.isEqualTo("mysql_password");
+			
+			assertThat(this.context.getEnvironment().getProperty("spring.r2dbc.url"))
+				.isEqualTo(mysqlJdbcUrl.replace("jdbc:", "r2dbc:").substring(0, mysqlJdbcUrl.indexOf("?") + 1));
+			assertThat(
+				this.context.getEnvironment().getProperty("spring.r2dbc.username"))
+				.isEqualTo("mysql_username");
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.password"))
+				.isEqualTo("mysql_password");		
 
 		} finally {
 			System.clearProperty("VCAP_APPLICATION");
 		}
 	}
+	
+	@Test
+	public void testDataSource_r2dbcOptions() throws Exception {
+
+		// To make CloudPlatform test pass
+		try {
+			System.setProperty("VCAP_APPLICATION", "yes");
+
+			// To setup values used by CfEnv
+			File file = ResourceUtils.getFile("classpath:vcap-services-tls.json");
+			String fileContents = new String(Files.readAllBytes(file.toPath()));
+			mockVcapServices(fileContents);
+
+
+			environmentPostProcessor.postProcessEnvironment(this.context.getEnvironment(),
+					null);
+			assertThat(this.context.getEnvironment().getProperty("spring.datasource.url"))
+					.isEqualTo(tlsMysqlJdbcUrl);
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.datasource.username"))
+					.isEqualTo("mysql_username");
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.datasource.password"))
+					.isEqualTo("mysql_password");
+			
+			assertThat(this.context.getEnvironment().getProperty("spring.r2dbc.url"))
+				.isEqualTo(tlsMysqlJdbcUrl.replace("jdbc:", "r2dbc:").substring(0, tlsMysqlJdbcUrl.indexOf("?") + 1));
+			assertThat(
+				this.context.getEnvironment().getProperty("spring.r2dbc.username"))
+				.isEqualTo("mysql_username");
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.password"))
+				.isEqualTo("mysql_password");		
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.user"))
+				.isEqualTo("mysql_username");		
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.password"))
+				.isEqualTo("mysql_password");	
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.sslMode"))
+				.isEqualTo("VERIFY_IDENTITY");				
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.useSSL"))
+				.isEqualTo("true");				
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.requireSSL"))
+				.isEqualTo("true");		
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.tlsVersion"))
+				.isEqualTo("TLSv1.2");				
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.serverSslCert"))
+				.isEqualTo("/etc/ssl/certs/ca-certificates.crt");
+			assertThat(
+					this.context.getEnvironment().getProperty("spring.r2dbc.properties.serverSslCert"))
+				.isEqualTo("/etc/ssl/certs/ca-certificates.crt");			
+			
+		} finally {
+			System.clearProperty("VCAP_APPLICATION");
+		}
+	}	
 }

--- a/java-cfenv-boot/src/test/resources/vcap-services-tls.json
+++ b/java-cfenv-boot/src/test/resources/vcap-services-tls.json
@@ -1,0 +1,25 @@
+{
+  "p-mysql": [
+    {
+      "credentials": {
+        "hostname": "10.0.4.35",
+        "port": 3306,
+        "name": "mysql_name",
+        "username": "mysql_username",
+        "password": "mysql_password",
+        "uri": "mysql://mysql_username:mysql_password@10.0.4.35:3306/service_instance_db?reconnect=true",
+        "jdbcUrl": "jdbc:mysql://10.0.4.35:3306/service_instance_db?permitMysqlScheme&user=mysql_username&password=mysql_password&sslMode=VERIFY_IDENTITY&useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2&serverSslCert=/etc/ssl/certs/ca-certificates.crt"
+      },
+      "syslog_drain_url": null,
+      "volume_mounts": [],
+      "label": "p-mysql",
+      "provider": null,
+      "plan": "100mb",
+      "name": "mysql",
+      "tags": [
+        "mysql",
+        "relational"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
basically, I just rebased on main #262, and removed @gm2552 code for MariaDB since it was merged already (support for mariadb)

@pivotal-david-osullivan , I could push `spring-music` with this branch and still get, with a bound mariadb, those properties from the actuator


```
 {
      "name": "cfenvjdbc",
      "properties": {
        "spring.datasource.url": {
          "value": "jdbc:mariadb://mad70744d.service.dc1.a9ssvc:3306/mad70744d?user=a9sa7fcc57a23fa9d05995dcd51c364&password=a9s6da4cc5f001593b8970eb5487f1fe148b281f476"
        },
        "spring.datasource.username": {
          "value": "a9sa7fcc57a23fa9d05995dcd51c364"
        },
        "spring.datasource.password": {
          "value": "a9s6da4cc5f001593b8970eb5487f1fe148b281f476"
        },
        "spring.datasource.driver-class-name": {
          "value": "org.mariadb.jdbc.Driver"
        },
        "spring.r2dbc.url": {
          "value": "r2dbc:mariadb://mad70744d.service.dc1.a9ssvc:3306/mad70744d"
        },
        "spring.r2dbc.username": {
          "value": "a9sa7fcc57a23fa9d05995dcd51c364"
        },
        "spring.r2dbc.password": {
          "value": "a9s6da4cc5f001593b8970eb5487f1fe148b281f476"
        },
        "spring.r2dbc.properties.password": {
          "value": "a9s6da4cc5f001593b8970eb5487f1fe148b281f476"
        },
        "spring.r2dbc.properties.user": {
          "value": "a9sa7fcc57a23fa9d05995dcd51c364"
        }
      }
```

(service was destroyed before adding this comment, no issue with credentials)

Good to go!!!! 🚀 