### PR TITLE
Fix ci: there was an issue during publishing

### DIFF
--- a/java-cfenv-all/build.gradle
+++ b/java-cfenv-all/build.gradle
@@ -111,5 +111,6 @@ publishing {
 
 assemble.dependsOn shadowJar
 build.dependsOn shadowJar
+generateMetadataFileForShadowPublication.dependsOn jar
 publishShadowPublicationToMavenRepository.onlyIf { false }
 publishShadowPublicationToMaven2Repository.onlyIf { false }


### PR DESCRIPTION
    Reason: Task ':java-cfenv-all:generateMetadataFileForShadowPublication' uses this output of task ':java-cfenv-all:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.