### PR TITLE
chore: make the genai processor more lenient against the new endpoint format

### DIFF
--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/GenAIChatCfEnvProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/GenAIChatCfEnvProcessor.java
@@ -28,6 +28,7 @@ import io.pivotal.cfenv.core.CfService;
  *
  * @author Stuart Charlton
  * @author Ed King
+ * @author Gareth Evans
  **/
 public class GenAIChatCfEnvProcessor implements CfEnvProcessor {
 
@@ -36,7 +37,7 @@ public class GenAIChatCfEnvProcessor implements CfEnvProcessor {
 		boolean isGenAIService = service.existsByTagIgnoreCase("genai") || service.existsByLabelStartsWith("genai");
 		if (isGenAIService) {
 			ArrayList<String> modelCapabilities = (ArrayList<String>) service.getCredentials().getMap().get("model_capabilities");
-			return modelCapabilities.contains("chat");
+			return (modelCapabilities != null && modelCapabilities.contains("chat"));
 		}
 
 		return false;

--- a/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/GenAIEmbeddingCfEnvProcessor.java
+++ b/java-cfenv-boot/src/main/java/io/pivotal/cfenv/spring/boot/GenAIEmbeddingCfEnvProcessor.java
@@ -28,6 +28,7 @@ import io.pivotal.cfenv.core.CfService;
  *
  * @author Stuart Charlton
  * @author Ed King
+ * @author Gareth Evans
  **/
 public class GenAIEmbeddingCfEnvProcessor implements CfEnvProcessor {
 
@@ -36,7 +37,7 @@ public class GenAIEmbeddingCfEnvProcessor implements CfEnvProcessor {
 		boolean isGenAIService = service.existsByTagIgnoreCase("genai") || service.existsByLabelStartsWith("genai");
 		if (isGenAIService) {
 			ArrayList<String> modelCapabilities = (ArrayList<String>) service.getCredentials().getMap().get("model_capabilities");
-			return modelCapabilities.contains("embedding");
+			return (modelCapabilities != null && modelCapabilities.contains("embedding"));
 		}
 
 		return false;

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/GenAIChatCfEnvProcessorTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/GenAIChatCfEnvProcessorTests.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Stuart Charlton
  * @author Ed King
+ * @author Gareth Evans
  */
 public class GenAIChatCfEnvProcessorTests extends AbstractCfEnvTests {
 
@@ -42,6 +43,23 @@ public class GenAIChatCfEnvProcessorTests extends AbstractCfEnvTests {
 		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.base-url")).isEqualTo(EXPECTED_URI_FROM_JSON_FILE);
 		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.api-key")).isEqualTo(EXPECTED_TOKEN_FROM_JSON_FILE);
 		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.options.model")).isEqualTo(EXPECTED_MODEL_FROM_JSON_FILE);
+
+		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.options.model")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.image.options.model")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.audio.transcription.options.model")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.audio.speech.options.model")).isNull();
+	}
+
+	@Test
+	public void testGenAIBootPropertiesWithChatModelCapabilityEndpointFormat() {
+		String TEST_GENAI_JSON_FILE = "test-genai-endpoint-chat-model.json";
+
+		mockVcapServices(getServicesPayload(readTestDataFile(TEST_GENAI_JSON_FILE)));
+
+		assertThat(getEnvironment().getProperty("spring.ai.openai.api-key")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.base-url")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.api-key")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.options.model")).isNull();
 
 		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.options.model")).isNull();
 		assertThat(getEnvironment().getProperty("spring.ai.openai.image.options.model")).isNull();

--- a/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/GenAIEmbeddingCfEnvProcessorTests.java
+++ b/java-cfenv-boot/src/test/java/io/pivotal/cfenv/spring/boot/GenAIEmbeddingCfEnvProcessorTests.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Stuart Charlton
  * @author Ed King
+ * @author Gareth Evans
  */
 public class GenAIEmbeddingCfEnvProcessorTests extends AbstractCfEnvTests {
 
@@ -42,6 +43,24 @@ public class GenAIEmbeddingCfEnvProcessorTests extends AbstractCfEnvTests {
 		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.base-url")).isEqualTo(EXPECTED_URI_FROM_JSON_FILE);
 		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.api-key")).isEqualTo(EXPECTED_TOKEN_FROM_JSON_FILE);
 		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.options.model")).isEqualTo(EXPECTED_MODEL_FROM_JSON_FILE);
+
+		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.options.model")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.image.options.model")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.audio.transcription.options.model")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.audio.speech.options.model")).isNull();
+	}
+
+	@Test
+	public void testGenAIBootPropertiesWithEmbeddingModelCapabilityEndpointFormat() {
+		String TEST_GENAI_JSON_FILE = "test-genai-endpoint-embedding-model.json";
+
+		mockVcapServices(getServicesPayload(readTestDataFile(TEST_GENAI_JSON_FILE)));
+
+		assertThat(getEnvironment().getProperty("spring.ai.openai.api-key")).isNull();
+
+		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.base-url")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.api-key")).isNull();
+		assertThat(getEnvironment().getProperty("spring.ai.openai.embedding.options.model")).isNull();
 
 		assertThat(getEnvironment().getProperty("spring.ai.openai.chat.options.model")).isNull();
 		assertThat(getEnvironment().getProperty("spring.ai.openai.image.options.model")).isNull();

--- a/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-genai-endpoint-chat-model.json
+++ b/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-genai-endpoint-chat-model.json
@@ -1,0 +1,20 @@
+{
+    "credentials": {
+      "endpoint": {
+        "api_base": "https://genai-proxy.tpcf.io/test",
+        "api_key": "sk-KW5kiNOKDd_1dFxsAjpVa",
+        "config_url": "https://genai-proxy.tpcf.io/test/config/v1/endpoint"
+      }
+    },
+    "instance_name": "genai",
+    "label": "genai",
+    "name": "genai",
+    "plan": "meta-llama/Meta-Llama-3-8B",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+       "genai",
+       "llm"
+    ],
+    "volume_mounts": []
+}

--- a/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-genai-endpoint-embedding-model.json
+++ b/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-genai-endpoint-embedding-model.json
@@ -1,0 +1,20 @@
+{
+    "credentials": {
+      "endpoint": {
+        "api_base": "https://genai-proxy.tpcf.io/test",
+        "api_key": "sk-KW5kiNOKDd_1dFxsAjpVa",
+        "config_url": "https://genai-proxy.tpcf.io/test/config/v1/endpoint"
+      }
+    },
+    "instance_name": "genai",
+    "label": "genai",
+    "name": "genai",
+    "plan": "mixedbread-ai/mxbai-embed-large-v1",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+       "genai",
+       "llm"
+    ],
+    "volume_mounts": []
+}


### PR DESCRIPTION
With the 10.2.0 genai tile release, there is a new binding format. This PR allows the existing logic to continue to function and not fail against a missing model_capabilities key.