### PR TITLE
Add support for Redis Sentinel HA Setup (#32).

### DIFF
--- a/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-redis-info-sentinel-tls.json
+++ b/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-redis-info-sentinel-tls.json
@@ -1,0 +1,24 @@
+{
+  "name": "$serviceName",
+  "label": "rediscloud",
+  "plan": "ha",
+  "tags": [ "redis", "key-value" ],
+  "credentials": {
+    "master_name": "$sentinelMaster",
+    "password": "$redisPassword",
+    "port": "$redisPort",
+    "sentinel_password": "$sentinelPassword",
+    "sentinels": [
+      {
+        "host": "$sentinel1-hostname",
+        "port": "$sentinel1-port",
+        "tls_port": "$sentinel1-tlsPort"
+      },
+      {
+        "host": "$sentinel2-hostname",
+        "port": "$sentinel2-port",
+        "tls_port": "$sentinel2-tlsPort"
+      }
+    ]
+  }
+}

--- a/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-redis-info-sentinel.json
+++ b/java-cfenv-boot/src/test/resources/io/pivotal/cfenv/spring/boot/test-redis-info-sentinel.json
@@ -1,0 +1,22 @@
+{
+  "name": "$serviceName",
+  "label": "rediscloud",
+  "plan": "ha",
+  "tags": [ "redis", "key-value" ],
+  "credentials": {
+    "master_name": "$sentinelMaster",
+    "password": "$redisPassword",
+    "port": "$redisPort",
+    "sentinel_password": "$sentinelPassword",
+    "sentinels": [
+      {
+        "host": "$sentinel1-hostname",
+        "port": "$sentinel1-port"
+      },
+      {
+        "host": "$sentinel2-hostname",
+        "port": "$sentinel2-port"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
As Tanzu for Valkey on Cloud Foundry supports high-available marketplace offerings, out-of-the box Spring Boot property binding was missing. This change try to implement just that, supporting Sentinel setup either with or without TLS.

This implementation is working for me (locally). Please let me know if any test and or quality checks are still required.