### PR TITLE
Upgrade Spring Boot from 3.5.8 to 3.5.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 
 [versions]
-springBoot = "3.5.8"
+springBoot = "3.5.9"
 springAi = "1.1.2"
 jmockit = "1.50"
 shadow = "8.3.9"


### PR DESCRIPTION
This PR upgrades Spring Boot from version 3.5.8 to 3.5.9.