### PR TITLE
Support multiple hosts for PostgreSQL and MySQL

### DIFF
--- a/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/MySqlJdbcUrlCreator.java
+++ b/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/MySqlJdbcUrlCreator.java
@@ -87,8 +87,8 @@ public class MySqlJdbcUrlCreator extends AbstractJdbcUrlCreator {
 	@Override
 	public String buildJdbcUrlFromUriField(CfCredentials cfCredentials) {
 		UriInfo uriInfo = cfCredentials.getUriInfo(MYSQL_SCHEME);
-		return String.format("%s%s://%s%s/%s%s%s", JDBC_PREFIX, MYSQL_SCHEME,
-				uriInfo.getHost(), uriInfo.formatPort(), uriInfo.getPath(),
+		return String.format("%s%s://%s/%s%s%s", JDBC_PREFIX, MYSQL_SCHEME,
+				uriInfo.getHostAndPort(), uriInfo.getPath(),
 				uriInfo.formatUserNameAndPasswordQuery(), uriInfo.formatQuery());
 	}
 }

--- a/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/PostgresqlJdbcUrlCreator.java
+++ b/java-cfenv-jdbc/src/main/java/io/pivotal/cfenv/jdbc/PostgresqlJdbcUrlCreator.java
@@ -48,8 +48,8 @@ public class PostgresqlJdbcUrlCreator extends AbstractJdbcUrlCreator {
 	@Override
 	public String buildJdbcUrlFromUriField(CfCredentials cfCredentials) {
 		UriInfo uriInfo = cfCredentials.getUriInfo(POSTGRES_JDBC_SCHEME);
-		return String.format("%s%s://%s%s/%s%s%s", JDBC_PREFIX, POSTGRES_JDBC_SCHEME,
-				uriInfo.getHost(), uriInfo.formatPort(), uriInfo.getPath(),
+		return String.format("%s%s://%s/%s%s%s", JDBC_PREFIX, POSTGRES_JDBC_SCHEME,
+				uriInfo.getHostAndPort(), uriInfo.getPath(),
 				uriInfo.formatUserNameAndPasswordQuery(), uriInfo.formatQuery());
 	}
 

--- a/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/MySqlJdbcTests.java
+++ b/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/MySqlJdbcTests.java
@@ -57,6 +57,23 @@ public class MySqlJdbcTests extends AbstractJdbcTests {
 	}
 
 	@Test
+	public void mysqlServiceCreationMultiHost() {
+		String name = "database-1";
+
+		mockVcapServices(getServicesPayload(getMysqlServicePayloadMultiHost("mysql-1",
+				hostname, port, username, password, name)));
+
+		CfJdbcEnv cfJdbcEnv = new CfJdbcEnv();
+		CfJdbcService cfJdbcService = cfJdbcEnv.findJdbcServiceByName("mysql-1");
+
+		assertThat(cfJdbcService.getJdbcUrl()).isEqualTo(String.format(
+				"jdbc:mysql://host1:3306,host2:3306/%s?user=%s&password=%s", name,
+				UriInfo.urlEncode(username), UriInfo.urlEncode(password)));
+		assertThat(cfJdbcService.getUsername()).isEqualTo(username);
+		assertThat(cfJdbcService.getPassword()).isEqualTo(password);
+	}
+
+	@Test
 	public void mysqlServiceCreationWithLabelNoTags() {
 		String name1 = "database-1";
 		String name2 = "database-2";
@@ -341,6 +358,12 @@ public class MySqlJdbcTests extends AbstractJdbcTests {
 			String user, String password, String name) {
 		return getTemplatedPayload("test-mysql-info.json", serviceName, hostname, port,
 				user, password, name);
+	}
+
+	private String getMysqlServicePayloadMultiHost(String serviceName, String hostname,
+			int port, String user, String password, String name) {
+		return getTemplatedPayload("test-mysql-info-multi-host.json", serviceName, hostname,
+				port, user, password, name);
 	}
 
 	private String getMysqlServicePayloadWithLabelNoTags(String serviceName,

--- a/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/PostgresqlJdbcTests.java
+++ b/java-cfenv-jdbc/src/test/java/io/pivotal/cfenv/jdbc/PostgresqlJdbcTests.java
@@ -127,6 +127,24 @@ public class PostgresqlJdbcTests extends AbstractJdbcTests {
 	}
 
 	@Test
+	public void postgresqlServiceCreationMultiHost() {
+		String name1 = "database-1";
+
+		mockVcapServices(getServicesPayload(
+				getPostgresqlServicePayloadMultiHost("postgresql-1", hostname, port, username, password, name1)));
+
+		CfJdbcEnv cfJdbcEnv = new CfJdbcEnv();
+		CfJdbcService cfJdbcService = cfJdbcEnv.findJdbcServiceByName("postgresql-1");
+
+		assertThat(cfJdbcService.getJdbcUrl()).isEqualTo(String.format(
+				"jdbc:postgresql://host1:5432,host2:5432/%s?user=%s&password=%s", name1,
+				UriInfo.urlEncode(username), UriInfo.urlEncode(password)));
+		assertThat(cfJdbcService.getUsername()).isEqualTo(username);
+		assertThat(cfJdbcService.getPassword()).isEqualTo(password);
+		assertThat(cfJdbcService.getDriverClassName()).isEqualTo("org.postgresql.Driver");
+	}
+
+	@Test
 	public void postgresqlServiceCreationNoLabelNoTags() {
 		String name1 = "database-1";
 		String name2 = "database-2";
@@ -228,6 +246,13 @@ public class PostgresqlJdbcTests extends AbstractJdbcTests {
 			String hostname, int port,
 			String user, String password, String name) {
 		return getTemplatedPayload("test-postgresql-info-no-label-no-tags.json", serviceName,
+				hostname, port, user, password, name);
+	}
+
+	private String getPostgresqlServicePayloadMultiHost(String serviceName,
+			String hostname, int port,
+			String user, String password, String name) {
+		return getTemplatedPayload("test-postgresql-info-multi-host.json", serviceName,
 				hostname, port, user, password, name);
 	}
 

--- a/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-mysql-info-multi-host.json
+++ b/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-mysql-info-multi-host.json
@@ -1,0 +1,11 @@
+{
+  "name": "$serviceName",
+  "label": "cleardb",
+  "tags": [
+    "mysql"
+  ],
+  "plan": "free",
+  "credentials": {
+    "uri": "mysql://$user:$password@host1:3306,host2:3306/$name"
+  }
+}

--- a/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-postgresql-info-multi-host.json
+++ b/java-cfenv-jdbc/src/test/resources/io/pivotal/cfenv/jdbc/test-postgresql-info-multi-host.json
@@ -1,0 +1,9 @@
+{
+	"name": "$serviceName",
+	"label": "elephantsql",
+	"plan": "free",
+	"tags": [ "postgresql" ],
+	"credentials": {
+		"uri": "postgres://$user:$password@host1:5432,host2:5432/$name"
+	}
+}

--- a/java-cfenv/src/main/java/io/pivotal/cfenv/core/UriInfo.java
+++ b/java-cfenv/src/main/java/io/pivotal/cfenv/core/UriInfo.java
@@ -79,7 +79,7 @@ public class UriInfo {
 		this.path = parsePath(uri);
 		this.query = uri.getQuery();
 
-		String authority = uri.getAuthority();
+		String authority = uri.getRawAuthority();
 		if (uri.getHost() != null) {
 			this.host = uri.getHost();
 			this.port = uri.getPort();
@@ -93,7 +93,10 @@ public class UriInfo {
 			// host1:port1,host2:port2 failover syntax) isn't valid
 			// server-based authority per RFC 3986, so java.net.URI parses
 			// it as a registry-based authority: getHost()/getPort() come
-			// back null/-1 even though getAuthority() has the full value.
+			// back null/-1 even though getRawAuthority() has the full value.
+			// Use the raw (not percent-decoded) form so a password
+			// containing an encoded ',' ':' or '@' isn't mistaken for a
+			// delimiter.
 			parseAuthority(authority);
 		}
 		else {

--- a/java-cfenv/src/main/java/io/pivotal/cfenv/core/UriInfo.java
+++ b/java-cfenv/src/main/java/io/pivotal/cfenv/core/UriInfo.java
@@ -46,6 +46,8 @@ public class UriInfo {
 
 	private String uriString;
 
+	private String hosts;
+
 	public UriInfo(String scheme, String host, int port, String username,
 				   String password) {
 		this(scheme, host, port, username, password, null, null);
@@ -74,14 +76,64 @@ public class UriInfo {
 
 		URI uri = getUri();
 		this.scheme = uri.getScheme();
-		this.host = uri.getHost();
-		this.port = uri.getPort();
 		this.path = parsePath(uri);
 		this.query = uri.getQuery();
 
-		String[] userinfo = parseUserinfo(uri);
-		this.userName = urlDecode(userinfo[0]);
-		this.password = urlDecode(userinfo[1]);
+		String authority = uri.getAuthority();
+		if (uri.getHost() != null) {
+			this.host = uri.getHost();
+			this.port = uri.getPort();
+
+			String[] userinfo = parseUserinfo(uri);
+			this.userName = urlDecode(userinfo[0]);
+			this.password = urlDecode(userinfo[1]);
+		}
+		else if (authority != null && authority.substring(authority.lastIndexOf('@') + 1).contains(",")) {
+			// A multi-host authority (e.g. postgresql's
+			// host1:port1,host2:port2 failover syntax) isn't valid
+			// server-based authority per RFC 3986, so java.net.URI parses
+			// it as a registry-based authority: getHost()/getPort() come
+			// back null/-1 even though getAuthority() has the full value.
+			parseAuthority(authority);
+		}
+		else {
+			// Some non-standard, driver-specific formats (e.g. SQL Server's
+			// ;property=value suffix) also fail server-based parsing but
+			// aren't a list of hosts either; leave host/port unset as before
+			// and let the caller fall back to its own parsing of uriString.
+			this.host = uri.getHost();
+			this.port = uri.getPort();
+		}
+	}
+
+	private void parseAuthority(String authority) {
+		String hostsPart = authority;
+
+		int at = authority.lastIndexOf('@');
+		if (at != -1) {
+			String userInfo = authority.substring(0, at);
+			hostsPart = authority.substring(at + 1);
+
+			String[] userPass = userInfo.split(":");
+			if (userPass.length != 2) {
+				throw new IllegalArgumentException("Bad userinfo in URI: " + uriString);
+			}
+			this.userName = urlDecode(userPass[0]);
+			this.password = urlDecode(userPass[1]);
+		}
+
+		this.hosts = hostsPart;
+
+		String firstHost = hostsPart.split(",")[0];
+		int colon = firstHost.lastIndexOf(':');
+		if (colon != -1) {
+			this.host = firstHost.substring(0, colon);
+			this.port = Integer.parseInt(firstHost.substring(colon + 1));
+		}
+		else {
+			this.host = firstHost;
+			this.port = -1;
+		}
 	}
 
 	public static String urlDecode(String s) {
@@ -163,6 +215,21 @@ public class UriInfo {
 			return String.format(":%d", getPort());
 		}
 		return "";
+	}
+
+	/**
+	 * Returns the host(s) and port(s) as they should appear in the authority
+	 * section of a URI. For a single-host URI this is equivalent to
+	 * {@code getHost() + formatPort()}. For a multi-host URI (e.g.
+	 * PostgreSQL's {@code host1:port1,host2:port2} failover syntax), the
+	 * full, unmodified host list is returned since {@link #getHost()} and
+	 * {@link #getPort()} only expose the first host.
+	 */
+	public String getHostAndPort() {
+		if (hosts != null) {
+			return hosts;
+		}
+		return getHost() + formatPort();
 	}
 
 	public String formatQuery() {

--- a/java-cfenv/src/test/java/io/pivotal/cfenv/core/UriInfoTests.java
+++ b/java-cfenv/src/test/java/io/pivotal/cfenv/core/UriInfoTests.java
@@ -62,6 +62,35 @@ public class UriInfoTests {
 	}
 
 	@Test
+	public void createMultiHostUri() {
+		String uri = "postgresql://joe:joes_password@host1:5432,host2:5432/big_db?p1=v1";
+		UriInfo uriInfo = new UriInfo(uri);
+
+		assertThat(uriInfo.getScheme()).isEqualTo("postgresql");
+		assertThat(uriInfo.getHost()).isEqualTo("host1");
+		assertThat(uriInfo.getPort()).isEqualTo(5432);
+		assertThat(uriInfo.getUsername()).isEqualTo("joe");
+		assertThat(uriInfo.getPassword()).isEqualTo("joes_password");
+		assertThat(uriInfo.getPath()).isEqualTo("big_db");
+		assertThat(uriInfo.getQuery()).isEqualTo("p1=v1");
+		assertThat(uriInfo.getHostAndPort()).isEqualTo("host1:5432,host2:5432");
+		assertThat(uri).isEqualTo(uriInfo.getUriString());
+	}
+
+	@Test
+	public void createMultiHostUriNoUserInfo() {
+		String uri = "postgresql://host1:5432,host2:5432/big_db";
+		UriInfo uriInfo = new UriInfo(uri);
+
+		assertThat(uriInfo.getHostAndPort()).isEqualTo("host1:5432,host2:5432");
+		assertThat(uriInfo.getHost()).isEqualTo("host1");
+		assertThat(uriInfo.getPort()).isEqualTo(5432);
+		assertThat(uriInfo.getUsername()).isNull();
+		assertThat(uriInfo.getPassword()).isNull();
+		assertThat(uriInfo.getPath()).isEqualTo("big_db");
+	}
+
+	@Test
 	public void createWithExplicitParameters() {
 		String uri = "mysql://joe:joes_password@localhost:1527/big_db";
 		UriInfo uriInfo = new UriInfo("mysql", "localhost", 1527, "joe", "joes_password",

--- a/java-cfenv/src/test/java/io/pivotal/cfenv/core/UriInfoTests.java
+++ b/java-cfenv/src/test/java/io/pivotal/cfenv/core/UriInfoTests.java
@@ -78,6 +78,34 @@ public class UriInfoTests {
 	}
 
 	@Test
+	public void createMultiHostUriNonPostgresScheme() {
+		// The multi-host authority format isn't postgresql-specific; mysql and
+		// mariadb use the same host1:port1,host2:port2 syntax for failover.
+		String uri = "mysql://joe:joes_password@host1:3306,host2:3306/big_db";
+		UriInfo uriInfo = new UriInfo(uri);
+
+		assertThat(uriInfo.getScheme()).isEqualTo("mysql");
+		assertThat(uriInfo.getHostAndPort()).isEqualTo("host1:3306,host2:3306");
+		assertThat(uriInfo.getHost()).isEqualTo("host1");
+		assertThat(uriInfo.getPort()).isEqualTo(3306);
+		assertThat(uriInfo.getUsername()).isEqualTo("joe");
+		assertThat(uriInfo.getPassword()).isEqualTo("joes_password");
+		assertThat(uriInfo.getPath()).isEqualTo("big_db");
+	}
+
+	@Test
+	public void createSingleHostUriIsUnaffectedByMultiHostParsing() {
+		// A standard single-host authority must keep using java.net.URI's
+		// server-based parsing, never the comma-detection fallback.
+		String uri = "mysql://joe:joes_password@localhost:1527/big_db";
+		UriInfo uriInfo = new UriInfo(uri);
+
+		assertUriInfoEquals(uriInfo, "localhost", 1527, "joe", "joes_password", "big_db",
+				null);
+		assertThat(uriInfo.getHostAndPort()).isEqualTo("localhost:1527");
+	}
+
+	@Test
 	public void createMultiHostUriWithEncodedDelimiterInPassword() {
 		String uri = "postgresql://joe:pa%3Ass@host1:5432,host2:5432/big_db";
 		UriInfo uriInfo = new UriInfo(uri);

--- a/java-cfenv/src/test/java/io/pivotal/cfenv/core/UriInfoTests.java
+++ b/java-cfenv/src/test/java/io/pivotal/cfenv/core/UriInfoTests.java
@@ -78,6 +78,16 @@ public class UriInfoTests {
 	}
 
 	@Test
+	public void createMultiHostUriWithEncodedDelimiterInPassword() {
+		String uri = "postgresql://joe:pa%3Ass@host1:5432,host2:5432/big_db";
+		UriInfo uriInfo = new UriInfo(uri);
+
+		assertThat(uriInfo.getUsername()).isEqualTo("joe");
+		assertThat(uriInfo.getPassword()).isEqualTo("pa:ss");
+		assertThat(uriInfo.getHostAndPort()).isEqualTo("host1:5432,host2:5432");
+	}
+
+	@Test
 	public void createMultiHostUriNoUserInfo() {
 		String uri = "postgresql://host1:5432,host2:5432/big_db";
 		UriInfo uriInfo = new UriInfo(uri);


### PR DESCRIPTION
Addresses #128

`java.net.URI` cannot parse a multi-host authority such as
`jdbc:postgresql://host1:port1,host2:port2/database` — it falls back to
registry-based parsing, where `getHost()` returns `null` and `getPort()`
returns `-1`, even though `getAuthority()` still holds the full value.

## Changes

- `UriInfo` now detects that fallback and, when the authority contains a
  comma, parses the host list manually. `getHost()`/`getPort()` keep
  returning the first host for backwards compatibility, and a new
  `getHostAndPort()` accessor exposes the full list.
- Parsing uses `getRawAuthority()` rather than the percent-decoded
  `getAuthority()`, so a password containing an encoded `:`, `,` or `@`
  is not mistaken for a delimiter. Decoding happens after splitting,
  matching the existing `parseUserinfo()` behaviour.
- `PostgresqlJdbcUrlCreator` uses `getHostAndPort()` so every host
  survives into the generated JDBC URL.
- `MySqlJdbcUrlCreator` does the same. MySQL and MariaDB support the same
  `host1,host2` failover syntax, and it shares the `UriInfo` code path, so
  without this it would have silently emitted a first-host-only URL.
- Authorities that fail server-based parsing without containing a comma
  (for example SQL Server’s `;property=value` suffix) keep their previous
  behaviour and continue to be handled by their own creator.

## Tests

- `UriInfoTests`: multi-host with and without userinfo, a percent-encoded
  `:` in the password, a non-PostgreSQL (mysql) multi-host authority, and
  a single-host case asserting the standard path is unaffected.
- `PostgresqlJdbcTests` / `MySqlJdbcTests`: end-to-end VCAP_SERVICES
  payloads asserting all hosts reach the JDBC URL.